### PR TITLE
9 examine token for domain and role to allow or deny access

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,6 +134,13 @@ app.get('/secure-data', authenticate, (req, res) => {
     res.json({ message: 'This is secure data.' });
 });
 
+app.get('/user/hasgroup', authenticate, (req, res) => {
+    const roles = req.user?.roles;
+    const groupEmail = req.query.groupEmail;
+    const hasGroup =  roles?.some(role => role.email === groupEmail) ?? false;
+    res.json({ hasgroup: hasGroup });
+});
+
 app.get("/msg", async (req, res, next) => {
     const dbResult = await testdb();
     res.json({
@@ -143,7 +150,7 @@ app.get("/msg", async (req, res, next) => {
     });
 });
 
-app.get("/search", async (req, res, next) => {
+app.get("/search", authenticate, async (req, res, next) => {
     const searchRequest = new SearchRequest(req.query);
     const dbResult = await search(searchRequest);
     const searchResults = new SearchResults(dbResult);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@google-cloud/iam": "^1.3.0",
+        "cors": "^2.8.5",
         "dotenv": "^16.4.7",
         "express": "^4.21.1",
         "google-auth-library": "^9.15.0",
@@ -398,6 +399,19 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
@@ -1174,6 +1188,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-hash": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "@google-cloud/iam": "^1.3.0",
+    "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.1",
     "google-auth-library": "^9.15.0",


### PR DESCRIPTION
Doing the authorization group lookup on the API side and allowing the UI to check which groups the user is part of by making a call an providing the group email.

Example:

`/user/hasgroup?groupEmail=sshf_app_dev_full_access@starsandstripeshonorflight.org`

Returns:

```
{
    "hasgroup": true
}
```

Search endpoint now requires authorization.
(I have a Postman collection I can share, if that is a help.)
