### PR TITLE
22 adjust hasgroup endpoint to work for non admin users

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,9 +135,7 @@ async function getGroupMemberships(token, userData) {
             key: process.env.GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY.replace(/\\n/g, '\n'),
             scopes: [
                 'https://www.googleapis.com/auth/admin.directory.group.readonly'
-            ],
-            // Specify the user to impersonate (should be a Google Workspace admin)
-            subject: process.env.GOOGLE_WORKSPACE_ADMIN_EMAIL
+            ]
         });
 
         // Create the Admin Directory API client with the delegated service account

--- a/index.js
+++ b/index.js
@@ -127,7 +127,7 @@ async function dbSession(req, res, next) {
     }
 }
 
-async function getGroupMemberships(token, userData) {
+async function getGroupMemberships(userData) {
     try {
         
         // First try using Application Default Credentials (will work in Cloud Run)
@@ -234,7 +234,7 @@ async function authenticate(req, res, next) {
         const userData = userResponse.data;
 
         // Fetch group memberships
-        const groups = await getGroupMemberships(token, userData);
+        const groups = await getGroupMemberships(userData);
 
         // Map groups to roles (customize this based on your needs)
         const roles = groups.map(group => ({

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "dotenv": "^16.4.7",
         "express": "^4.21.1",
         "google-auth-library": "^9.15.0",
+        "googleapis": "^148.0.0",
         "node-fetch": "^3.3.2",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.0"
@@ -1678,6 +1679,36 @@
         }
       }
     },
+    "node_modules/googleapis": {
+      "version": "148.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-148.0.0.tgz",
+      "integrity": "sha512-8PDG5VItm6E1TdZWDqtRrUJSlBcNwz0/MwCa6AL81y/RxPGXJRUwKqGZfCoVX1ZBbfr3I4NkDxBmeTyOAZSWqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^9.0.0",
+        "googleapis-common": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.2.0.tgz",
+      "integrity": "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^6.0.3",
+        "google-auth-library": "^9.7.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -3248,6 +3279,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "license": "BSD"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.1",
+    "googleapis": "^148.0.0",
     "google-auth-library": "^9.15.0",
     "node-fetch": "^3.3.2",
     "swagger-jsdoc": "^6.2.8",


### PR DESCRIPTION
Switched to using Google APIs library in place of raw fetch.
Try first to use default credentials in case the app is running in the CloudRun environment under the service host.
If that fails, try reading the environment variables for the service account and it's auth key to work with the service locally.

We will use a different service account for the production environment and we will not generate an auth key for that one.
That will mean you will only be able to run against the dev environment from a local dev machine, which is fine.