### PR TITLE
33 veterans endpoint for pairing and other uses

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ import { getSecureData } from './routes/secure.js';
 import { getHasGroup } from './routes/user.js';
 import { getSearch } from './routes/search.js';
 import { createDocument, retrieveDocument, updateDocument, deleteDocument } from './routes/docs.js';
-import { createVeteran, retrieveVeteran, updateVeteran, deleteVeteran } from './routes/veterans.js';
+import { createVeteran, retrieveVeteran, updateVeteran, deleteVeteran, searchUnpairedVeterans } from './routes/veterans.js';
 import { createGuardian, retrieveGuardian, updateGuardian, deleteGuardian } from './routes/guardians.js';
 import { listFlights, createFlight, retrieveFlight, updateFlight } from './routes/flights.js';
 
@@ -63,6 +63,7 @@ app.delete("/docs/:id", authenticate, dbSession, deleteDocument);
 
 // Veteran-specific routes
 app.post("/veterans", authenticate, dbSession, createVeteran);
+app.get("/veterans/search", authenticate, dbSession, searchUnpairedVeterans);
 app.get("/veterans/:id", authenticate, dbSession, retrieveVeteran);
 app.put("/veterans/:id", authenticate, dbSession, updateVeteran);
 app.delete("/veterans/:id", authenticate, dbSession, deleteVeteran);

--- a/models/unpaired_veteran_request.js
+++ b/models/unpaired_veteran_request.js
@@ -1,0 +1,46 @@
+export class UnpairedVeteranRequest {
+    constructor(data = {}) {
+        // Set defaults
+        this.paired = data.paired === true || data.paired === 'true';
+        this.status = data.status || 'Active';
+        this.lastname = data.lastname || '';
+        this.limit = data.limit !== undefined && data.limit !== null ? data.limit : 25;
+    }
+
+    getViewName() {
+        if (this.paired) {
+            return null; // Will be handled in route as "Not Implemented"
+        }
+        return 'unpaired_veterans_by_last_name';
+    }
+
+    // Convert to query parameters for CouchDB
+    toQueryParams() {
+        const params = new URLSearchParams();
+        
+        if (this.limit) {
+            params.append('limit', this.limit);
+        }
+
+        // View key format: [status, lastname.toUpperCase()]
+        const lastnameUpper = this.lastname.toUpperCase();
+        const startKey = JSON.stringify([this.status, lastnameUpper]);
+        const endKey = JSON.stringify([this.status, lastnameUpper + '\ufff0']);
+        params.append('startkey', startKey);
+        params.append('endkey', endKey);
+        
+        return params.toString();
+    }
+
+    // Convert to JSON object
+    toJSON() {
+        return {
+            paired: this.paired,
+            status: this.status,
+            lastname: this.lastname,
+            limit: this.limit,
+            viewName: this.getViewName()
+        };
+    }
+}
+

--- a/models/unpaired_veteran_result.js
+++ b/models/unpaired_veteran_result.js
@@ -1,0 +1,25 @@
+export class UnpairedVeteranResult {
+    constructor(data) {
+        this.name = data.name || '';
+        this.city = data.city || '';
+        this.flight = data.flight || '';
+        this.prefs = data.prefs || '';
+    }
+
+    // Getter methods
+    getName() { return this.name; }
+    getCity() { return this.city; }
+    getFlight() { return this.flight; }
+    getPrefs() { return this.prefs; }
+
+    // Convert to JSON object
+    toJSON() {
+        return {
+            name: this.name,
+            city: this.city,
+            flight: this.flight,
+            prefs: this.prefs
+        };
+    }
+}
+

--- a/models/unpaired_veteran_results.js
+++ b/models/unpaired_veteran_results.js
@@ -1,0 +1,22 @@
+export class UnpairedVeteranResults {
+    constructor(data) {
+        this.results = data.rows.map(row => ({
+            id: row.id,
+            name: row.value.name || '',
+            city: row.value.city || '',
+            flight: row.value.flight || '',
+            prefs: row.value.prefs || ''
+        }));
+    }
+
+    // Getter method
+    getResults() {
+        return this.results;
+    }
+
+    // Convert to JSON object - returns array directly
+    toJSON() {
+        return this.results;
+    }
+}
+

--- a/routes/veterans.js
+++ b/routes/veterans.js
@@ -1,4 +1,6 @@
 import { Veteran } from '../models/veteran.js';
+import { UnpairedVeteranRequest } from '../models/unpaired_veteran_request.js';
+import { UnpairedVeteranResults } from '../models/unpaired_veteran_results.js';
 
 const dbUrl = process.env.DB_URL;
 const dbName = process.env.DB_NAME;
@@ -344,6 +346,127 @@ export async function deleteVeteran(req, res) {
         res.json(data);
     } catch (error) {
         console.error('Error deleting veteran:', error);
+        res.status(500).json({ error: error.message });
+    }
+}
+
+async function searchUnpaired(searchRequest, dbCookie) {
+    try {
+        const viewName = searchRequest.getViewName();
+        const queryParams = searchRequest.toQueryParams();
+        const url = `${dbUrl}/${dbName}/_design/basic/_view/${viewName}?${queryParams}&descending=false`;
+        
+        const response = await fetch(url, {
+            headers: {
+                'Cookie': dbCookie,
+                'Accept': 'application/json',
+                'Content-Type': 'application/json'
+            }
+        });
+        
+        const data = await response.json();
+        if (!response.ok) {
+            throw new Error(data.reason || data.error || 'Failed to search unpaired veterans');
+        }
+        
+        return data;
+    } catch (error) {
+        console.error('Database connection error:', error);
+        throw error;
+    }
+}
+
+/**
+ * @swagger
+ * /veterans/search:
+ *   get:
+ *     summary: Search for unpaired veterans
+ *     description: |
+ *       Searches for unpaired veterans based on provided criteria.
+ *       Currently only supports searching for unpaired veterans (paired=false).
+ *       The search uses the unpaired_veterans_by_last_name view which filters
+ *       veterans where guardian.id is empty.
+ *     tags: [Veterans]
+ *     security:
+ *       - GoogleAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: paired
+ *         schema:
+ *           type: boolean
+ *           default: false
+ *         description: Whether to search for paired veterans (currently not implemented)
+ *       - in: query
+ *         name: status
+ *         schema:
+ *           type: string
+ *           enum: ['Active', 'Flown', 'Deceased', 'Removed', 'Future-Spring', 'Future-Fall', 'Future-PostRestriction']
+ *           default: 'Active'
+ *         description: Flight status filter for the search
+ *       - in: query
+ *         name: lastname
+ *         schema:
+ *           type: string
+ *         description: Last name to search for (partial match, case-insensitive)
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 25
+ *         description: Maximum number of results to return
+ *     responses:
+ *       200:
+ *         description: Search completed successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/UnpairedVeteranResults'
+ *             example:
+ *               - id: "doc1"
+ *                 name: "John Smith"
+ *                 city: "Chicago, IL"
+ *                 flight: "F23"
+ *                 prefs: "Prefers window seat"
+ *               - id: "doc2"
+ *                 name: "Jane Doe"
+ *                 city: "New York, NY"
+ *                 flight: "F24"
+ *                 prefs: ""
+ *       501:
+ *         description: Not Implemented - paired=true is not yet supported
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *       401:
+ *         description: Unauthorized
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ */
+export async function searchUnpairedVeterans(req, res) {
+    try {
+        const searchRequest = new UnpairedVeteranRequest(req.query);
+        
+        // If paired is true, return Not Implemented
+        if (searchRequest.paired) {
+            return res.status(501).json({ error: 'Not Implemented: paired=true is not yet supported' });
+        }
+        
+        const dbResult = await searchUnpaired(searchRequest, req.dbCookie);
+        const searchResults = new UnpairedVeteranResults(dbResult);
+        res.json(searchResults.toJSON());
+    } catch (error) {
+        console.error('Error searching unpaired veterans:', error);
         res.status(500).json({ error: error.message });
     }
 } 

--- a/schemas/UnpairedVeteranResult.yaml
+++ b/schemas/UnpairedVeteranResult.yaml
@@ -1,0 +1,15 @@
+type: object
+properties:
+  name:
+    type: string
+    description: 'Full name of the veteran (first + last)'
+  city:
+    type: string
+    description: 'City and state of residence (city, state)'
+  flight:
+    type: string
+    description: 'Flight ID assignment'
+  prefs:
+    type: string
+    description: 'Guardian preference notes'
+

--- a/schemas/UnpairedVeteranResults.yaml
+++ b/schemas/UnpairedVeteranResults.yaml
@@ -1,0 +1,20 @@
+type: array
+items:
+  type: object
+  properties:
+    id:
+      type: string
+      description: 'Document ID'
+    name:
+      type: string
+      description: 'Full name of the veteran (first + last)'
+    city:
+      type: string
+      description: 'City and state of residence (city, state)'
+    flight:
+      type: string
+      description: 'Flight ID assignment'
+    prefs:
+      type: string
+      description: 'Guardian preference notes'
+

--- a/swagger/swagger.js
+++ b/swagger/swagger.js
@@ -60,7 +60,9 @@ const options = {
         Error: loadSchema('Error'),
         Veteran: loadSchema('Veteran'),
         Guardian: loadSchema('Guardian'),
-        Flight: loadSchema('Flight')
+        Flight: loadSchema('Flight'),
+        UnpairedVeteranResult: loadSchema('UnpairedVeteranResult'),
+        UnpairedVeteranResults: loadSchema('UnpairedVeteranResults')
       }
     },
     security: [

--- a/test/unpaired_veteran_request.test.js
+++ b/test/unpaired_veteran_request.test.js
@@ -1,0 +1,240 @@
+import { expect } from 'chai';
+import { UnpairedVeteranRequest } from '../models/unpaired_veteran_request.js';
+
+describe('UnpairedVeteranRequest', () => {
+    describe('constructor', () => {
+        it('should use default values when no data provided', () => {
+            const request = new UnpairedVeteranRequest();
+            expect(request.paired).to.equal(false);
+            expect(request.status).to.equal('Active');
+            expect(request.lastname).to.equal('');
+            expect(request.limit).to.equal(25);
+        });
+
+        it('should use provided values', () => {
+            const data = {
+                paired: false,
+                status: 'Flown',
+                lastname: 'Smith',
+                limit: 50
+            };
+            const request = new UnpairedVeteranRequest(data);
+            expect(request.paired).to.equal(false);
+            expect(request.status).to.equal('Flown');
+            expect(request.lastname).to.equal('Smith');
+            expect(request.limit).to.equal(50);
+        });
+
+        it('should handle paired as boolean true', () => {
+            const request = new UnpairedVeteranRequest({ paired: true });
+            expect(request.paired).to.equal(true);
+        });
+
+        it('should handle paired as string "true"', () => {
+            const request = new UnpairedVeteranRequest({ paired: 'true' });
+            expect(request.paired).to.equal(true);
+        });
+
+        it('should handle paired as boolean false', () => {
+            const request = new UnpairedVeteranRequest({ paired: false });
+            expect(request.paired).to.equal(false);
+        });
+
+        it('should handle paired as string "false"', () => {
+            const request = new UnpairedVeteranRequest({ paired: 'false' });
+            expect(request.paired).to.equal(false);
+        });
+
+        it('should handle undefined paired as false', () => {
+            const request = new UnpairedVeteranRequest({});
+            expect(request.paired).to.equal(false);
+        });
+
+        it('should handle empty string status and use default', () => {
+            const request = new UnpairedVeteranRequest({ status: '' });
+            expect(request.status).to.equal('Active');
+        });
+
+        it('should handle empty string lastname', () => {
+            const request = new UnpairedVeteranRequest({ lastname: '' });
+            expect(request.lastname).to.equal('');
+        });
+
+        it('should handle zero limit', () => {
+            const request = new UnpairedVeteranRequest({ limit: 0 });
+            expect(request.limit).to.equal(0);
+        });
+
+        it('should handle undefined limit and use default', () => {
+            const request = new UnpairedVeteranRequest({});
+            expect(request.limit).to.equal(25);
+        });
+    });
+
+    describe('getViewName', () => {
+        it('should return null when paired is true', () => {
+            const request = new UnpairedVeteranRequest({ paired: true });
+            expect(request.getViewName()).to.be.null;
+        });
+
+        it('should return null when paired is string "true"', () => {
+            const request = new UnpairedVeteranRequest({ paired: 'true' });
+            expect(request.getViewName()).to.be.null;
+        });
+
+        it('should return unpaired_veterans_by_last_name when paired is false', () => {
+            const request = new UnpairedVeteranRequest({ paired: false });
+            expect(request.getViewName()).to.equal('unpaired_veterans_by_last_name');
+        });
+
+        it('should return unpaired_veterans_by_last_name when paired is undefined', () => {
+            const request = new UnpairedVeteranRequest({});
+            expect(request.getViewName()).to.equal('unpaired_veterans_by_last_name');
+        });
+    });
+
+    describe('toQueryParams', () => {
+        it('should generate correct params with status and lastname', () => {
+            const request = new UnpairedVeteranRequest({
+                status: 'Active',
+                lastname: 'Smith',
+                limit: 25
+            });
+            const params = new URLSearchParams(request.toQueryParams());
+            expect(params.get('startkey')).to.equal('["Active","SMITH"]');
+            expect(params.get('endkey')).to.equal('["Active","SMITH\ufff0"]');
+            expect(params.get('limit')).to.equal('25');
+        });
+
+        it('should uppercase lastname in query params', () => {
+            const request = new UnpairedVeteranRequest({
+                status: 'Flown',
+                lastname: 'smith'
+            });
+            const params = new URLSearchParams(request.toQueryParams());
+            expect(params.get('startkey')).to.equal('["Flown","SMITH"]');
+            expect(params.get('endkey')).to.equal('["Flown","SMITH\ufff0"]');
+        });
+
+        it('should handle mixed case lastname', () => {
+            const request = new UnpairedVeteranRequest({
+                status: 'Active',
+                lastname: 'SmItH'
+            });
+            const params = new URLSearchParams(request.toQueryParams());
+            expect(params.get('startkey')).to.equal('["Active","SMITH"]');
+        });
+
+        it('should handle empty lastname', () => {
+            const request = new UnpairedVeteranRequest({
+                status: 'Active',
+                lastname: ''
+            });
+            const params = new URLSearchParams(request.toQueryParams());
+            expect(params.get('startkey')).to.equal('["Active",""]');
+            expect(params.get('endkey')).to.equal('["Active","\ufff0"]');
+        });
+
+        it('should include limit in params', () => {
+            const request = new UnpairedVeteranRequest({
+                status: 'Active',
+                lastname: 'Smith',
+                limit: 50
+            });
+            const params = new URLSearchParams(request.toQueryParams());
+            expect(params.get('limit')).to.equal('50');
+        });
+
+        it('should handle zero limit', () => {
+            const request = new UnpairedVeteranRequest({
+                status: 'Active',
+                lastname: 'Smith',
+                limit: 0
+            });
+            const params = new URLSearchParams(request.toQueryParams());
+            // URLSearchParams will convert 0 to "0", but the if check should prevent it
+            // Actually, looking at the code, if(this.limit) will be false for 0
+            // So limit won't be included
+            expect(params.get('limit')).to.be.null;
+        });
+
+        it('should handle different status values', () => {
+            const statuses = ['Flown', 'Deceased', 'Removed', 'Future-Spring', 'Future-Fall', 'Future-PostRestriction'];
+            
+            statuses.forEach(status => {
+                const request = new UnpairedVeteranRequest({
+                    status: status,
+                    lastname: 'Smith'
+                });
+                const params = new URLSearchParams(request.toQueryParams());
+                expect(params.get('startkey')).to.equal(`["${status}","SMITH"]`);
+                expect(params.get('endkey')).to.equal(`["${status}","SMITH\ufff0"]`);
+            });
+        });
+
+        it('should generate correct endkey with lastname concatenated with unicode character', () => {
+            const request = new UnpairedVeteranRequest({
+                status: 'Active',
+                lastname: 'Smith'
+            });
+            const params = new URLSearchParams(request.toQueryParams());
+            const endKey = params.get('endkey');
+            expect(endKey).to.equal('["Active","SMITH\ufff0"]');
+        });
+    });
+
+    describe('toJSON', () => {
+        it('should return correct JSON representation with paired false', () => {
+            const request = new UnpairedVeteranRequest({
+                paired: false,
+                status: 'Active',
+                lastname: 'Smith',
+                limit: 50
+            });
+            
+            const json = request.toJSON();
+            
+            expect(json).to.deep.equal({
+                paired: false,
+                status: 'Active',
+                lastname: 'Smith',
+                limit: 50,
+                viewName: 'unpaired_veterans_by_last_name'
+            });
+        });
+
+        it('should return correct JSON representation with paired true', () => {
+            const request = new UnpairedVeteranRequest({
+                paired: true,
+                status: 'Flown',
+                lastname: 'Jones',
+                limit: 25
+            });
+            
+            const json = request.toJSON();
+            
+            expect(json).to.deep.equal({
+                paired: true,
+                status: 'Flown',
+                lastname: 'Jones',
+                limit: 25,
+                viewName: null
+            });
+        });
+
+        it('should return correct JSON representation with defaults', () => {
+            const request = new UnpairedVeteranRequest();
+            
+            const json = request.toJSON();
+            
+            expect(json).to.deep.equal({
+                paired: false,
+                status: 'Active',
+                lastname: '',
+                limit: 25,
+                viewName: 'unpaired_veterans_by_last_name'
+            });
+        });
+    });
+});
+

--- a/test/unpaired_veteran_results.test.js
+++ b/test/unpaired_veteran_results.test.js
@@ -1,0 +1,241 @@
+import { expect } from 'chai';
+import { UnpairedVeteranResults } from '../models/unpaired_veteran_results.js';
+
+describe('UnpairedVeteranResults', () => {
+    const sampleData = {
+        total_rows: 2,
+        offset: 0,
+        rows: [
+            {
+                id: 'doc1',
+                key: ['Active', 'SMITH'],
+                value: {
+                    name: 'John Smith',
+                    city: 'Chicago, IL',
+                    flight: 'F23',
+                    prefs: 'Prefers window seat'
+                }
+            },
+            {
+                id: 'doc2',
+                key: ['Active', 'JONES'],
+                value: {
+                    name: 'Jane Jones',
+                    city: 'New York, NY',
+                    flight: 'F24',
+                    prefs: ''
+                }
+            }
+        ]
+    };
+
+    describe('constructor', () => {
+        it('should create instance with correct properties', () => {
+            const results = new UnpairedVeteranResults(sampleData);
+            expect(results.results).to.be.an('array');
+            expect(results.results).to.have.lengthOf(2);
+        });
+
+        it('should map rows to results with id, name, city, flight, prefs', () => {
+            const results = new UnpairedVeteranResults(sampleData);
+            expect(results.results[0]).to.deep.equal({
+                id: 'doc1',
+                name: 'John Smith',
+                city: 'Chicago, IL',
+                flight: 'F23',
+                prefs: 'Prefers window seat'
+            });
+            expect(results.results[1]).to.deep.equal({
+                id: 'doc2',
+                name: 'Jane Jones',
+                city: 'New York, NY',
+                flight: 'F24',
+                prefs: ''
+            });
+        });
+
+        it('should handle empty rows array', () => {
+            const emptyData = {
+                total_rows: 0,
+                offset: 0,
+                rows: []
+            };
+            const results = new UnpairedVeteranResults(emptyData);
+            expect(results.results).to.be.an('array');
+            expect(results.results).to.have.lengthOf(0);
+        });
+
+        it('should use empty string defaults for missing value fields', () => {
+            const incompleteData = {
+                total_rows: 1,
+                offset: 0,
+                rows: [
+                    {
+                        id: 'doc1',
+                        key: ['Active', 'SMITH'],
+                        value: {
+                            name: 'John Smith'
+                            // Missing city, flight, prefs
+                        }
+                    }
+                ]
+            };
+            const results = new UnpairedVeteranResults(incompleteData);
+            expect(results.results[0]).to.deep.equal({
+                id: 'doc1',
+                name: 'John Smith',
+                city: '',
+                flight: '',
+                prefs: ''
+            });
+        });
+
+        it('should handle null values in value fields', () => {
+            const nullData = {
+                total_rows: 1,
+                offset: 0,
+                rows: [
+                    {
+                        id: 'doc1',
+                        key: ['Active', 'SMITH'],
+                        value: {
+                            name: null,
+                            city: null,
+                            flight: null,
+                            prefs: null
+                        }
+                    }
+                ]
+            };
+            const results = new UnpairedVeteranResults(nullData);
+            // null || '' will result in '' due to the || operator
+            expect(results.results[0].name).to.equal('');
+            expect(results.results[0].city).to.equal('');
+            expect(results.results[0].flight).to.equal('');
+            expect(results.results[0].prefs).to.equal('');
+        });
+
+        it('should handle undefined values in value fields', () => {
+            const undefinedData = {
+                total_rows: 1,
+                offset: 0,
+                rows: [
+                    {
+                        id: 'doc1',
+                        key: ['Active', 'SMITH'],
+                        value: {
+                            name: 'John Smith'
+                            // city, flight, prefs are undefined
+                        }
+                    }
+                ]
+            };
+            const results = new UnpairedVeteranResults(undefinedData);
+            expect(results.results[0].name).to.equal('John Smith');
+            expect(results.results[0].city).to.equal('');
+            expect(results.results[0].flight).to.equal('');
+            expect(results.results[0].prefs).to.equal('');
+        });
+
+        it('should handle single row', () => {
+            const singleRowData = {
+                total_rows: 1,
+                offset: 0,
+                rows: [
+                    {
+                        id: 'doc1',
+                        key: ['Active', 'SMITH'],
+                        value: {
+                            name: 'John Smith',
+                            city: 'Chicago, IL',
+                            flight: 'F23',
+                            prefs: 'Prefers window seat'
+                        }
+                    }
+                ]
+            };
+            const results = new UnpairedVeteranResults(singleRowData);
+            expect(results.results).to.have.lengthOf(1);
+            expect(results.results[0].id).to.equal('doc1');
+            expect(results.results[0].name).to.equal('John Smith');
+        });
+
+        it('should ignore key field from rows', () => {
+            const results = new UnpairedVeteranResults(sampleData);
+            // Key should not be in the results
+            expect(results.results[0]).to.not.have.property('key');
+        });
+
+        it('should ignore total_rows and offset from input data', () => {
+            const results = new UnpairedVeteranResults(sampleData);
+            // These should not be in the results
+            expect(results.results).to.not.have.property('total_rows');
+            expect(results.results).to.not.have.property('offset');
+        });
+    });
+
+    describe('getResults', () => {
+        it('should return the results array', () => {
+            const results = new UnpairedVeteranResults(sampleData);
+            const returnedResults = results.getResults();
+            expect(returnedResults).to.be.an('array');
+            expect(returnedResults).to.have.lengthOf(2);
+            expect(returnedResults).to.deep.equal(results.results);
+        });
+
+        it('should return empty array when no rows', () => {
+            const emptyData = {
+                total_rows: 0,
+                offset: 0,
+                rows: []
+            };
+            const results = new UnpairedVeteranResults(emptyData);
+            expect(results.getResults()).to.be.an('array').that.is.empty;
+        });
+    });
+
+    describe('toJSON', () => {
+        it('should return the results array directly', () => {
+            const results = new UnpairedVeteranResults(sampleData);
+            const json = results.toJSON();
+            
+            expect(json).to.be.an('array');
+            expect(json).to.have.lengthOf(2);
+            expect(json).to.deep.equal(results.results);
+        });
+
+        it('should return array with correct structure', () => {
+            const results = new UnpairedVeteranResults(sampleData);
+            const json = results.toJSON();
+            
+            expect(json[0]).to.have.property('id');
+            expect(json[0]).to.have.property('name');
+            expect(json[0]).to.have.property('city');
+            expect(json[0]).to.have.property('flight');
+            expect(json[0]).to.have.property('prefs');
+            expect(json[0]).to.not.have.property('key');
+            expect(json[0]).to.not.have.property('value');
+        });
+
+        it('should return empty array for empty results', () => {
+            const emptyData = {
+                total_rows: 0,
+                offset: 0,
+                rows: []
+            };
+            const results = new UnpairedVeteranResults(emptyData);
+            const json = results.toJSON();
+            
+            expect(json).to.be.an('array').that.is.empty;
+        });
+
+        it('should return same reference as getResults', () => {
+            const results = new UnpairedVeteranResults(sampleData);
+            const json = results.toJSON();
+            const getResults = results.getResults();
+            
+            expect(json).to.equal(getResults);
+        });
+    });
+});
+

--- a/test/veterans_search.test.js
+++ b/test/veterans_search.test.js
@@ -1,0 +1,414 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { searchUnpairedVeterans } from '../routes/veterans.js';
+
+describe('Veterans Search Route', () => {
+    let req, res;
+
+    beforeEach(() => {
+        req = {
+            query: {
+                paired: false,
+                status: 'Active',
+                lastname: 'Smith',
+                limit: 25
+            },
+            dbCookie: 'auth-cookie'
+        };
+        res = {
+            status: sinon.stub().returnsThis(),
+            json: sinon.spy()
+        };
+        global.fetch = sinon.stub();
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    describe('searchUnpairedVeterans', () => {
+        it('should return search results with default parameters', async () => {
+            const mockDbResult = {
+                total_rows: 1,
+                offset: 0,
+                rows: [{
+                    id: 'doc1',
+                    key: ['Active', 'SMITH'],
+                    value: {
+                        name: 'John Smith',
+                        city: 'Chicago, IL',
+                        flight: 'F23',
+                        prefs: 'Prefers window seat'
+                    }
+                }]
+            };
+
+            global.fetch.resolves({
+                ok: true,
+                json: async () => mockDbResult
+            });
+
+            await searchUnpairedVeterans(req, res);
+
+            expect(res.json.calledOnce).to.be.true;
+            const response = res.json.firstCall.args[0];
+            expect(response).to.be.an('array');
+            expect(response).to.have.length(1);
+            expect(response[0].id).to.equal('doc1');
+            expect(response[0].name).to.equal('John Smith');
+            expect(response[0].city).to.equal('Chicago, IL');
+            expect(response[0].flight).to.equal('F23');
+            expect(response[0].prefs).to.equal('Prefers window seat');
+        });
+
+        it('should return search results with status filter', async () => {
+            req.query.status = 'Flown';
+            const mockDbResult = {
+                total_rows: 2,
+                offset: 0,
+                rows: [{
+                    id: 'doc1',
+                    key: ['Flown', 'JONES'],
+                    value: {
+                        name: 'Jane Jones',
+                        city: 'New York, NY',
+                        flight: 'F24',
+                        prefs: ''
+                    }
+                }, {
+                    id: 'doc2',
+                    key: ['Flown', 'JONES'],
+                    value: {
+                        name: 'Bob Jones',
+                        city: 'Boston, MA',
+                        flight: 'F24',
+                        prefs: 'No preferences'
+                    }
+                }]
+            };
+
+            global.fetch.resolves({
+                ok: true,
+                json: async () => mockDbResult
+            });
+
+            await searchUnpairedVeterans(req, res);
+
+            expect(res.json.calledOnce).to.be.true;
+            const response = res.json.firstCall.args[0];
+            expect(response).to.be.an('array');
+            expect(response).to.have.length(2);
+            expect(response[0].name).to.equal('Jane Jones');
+            expect(response[1].name).to.equal('Bob Jones');
+        });
+
+        it('should return search results with lastname filter', async () => {
+            req.query.lastname = 'Brown';
+            const mockDbResult = {
+                total_rows: 1,
+                offset: 0,
+                rows: [{
+                    id: 'doc3',
+                    key: ['Active', 'BROWN'],
+                    value: {
+                        name: 'Charlie Brown',
+                        city: 'Los Angeles, CA',
+                        flight: 'F25',
+                        prefs: 'Prefers aisle seat'
+                    }
+                }]
+            };
+
+            global.fetch.resolves({
+                ok: true,
+                json: async () => mockDbResult
+            });
+
+            await searchUnpairedVeterans(req, res);
+
+            expect(res.json.calledOnce).to.be.true;
+            const response = res.json.firstCall.args[0];
+            expect(response).to.be.an('array');
+            expect(response).to.have.length(1);
+            expect(response[0].name).to.equal('Charlie Brown');
+            expect(response[0].city).to.equal('Los Angeles, CA');
+            expect(response[0].flight).to.equal('F25');
+            expect(response[0].prefs).to.equal('Prefers aisle seat');
+        });
+
+        it('should return search results with limit parameter', async () => {
+            req.query.limit = 10;
+            const mockDbResult = {
+                total_rows: 5,
+                offset: 0,
+                rows: [{
+                    id: 'doc1',
+                    key: ['Active', 'SMITH'],
+                    value: {
+                        name: 'John Smith',
+                        city: 'Chicago, IL',
+                        flight: 'F23',
+                        prefs: ''
+                    }
+                }]
+            };
+
+            global.fetch.resolves({
+                ok: true,
+                json: async () => mockDbResult
+            });
+
+            await searchUnpairedVeterans(req, res);
+
+            expect(res.json.calledOnce).to.be.true;
+            // Verify the limit was used in the query
+            expect(global.fetch.calledOnce).to.be.true;
+            const fetchUrl = global.fetch.firstCall.args[0];
+            expect(fetchUrl).to.include('limit=10');
+        });
+
+        it('should return 501 Not Implemented when paired=true', async () => {
+            req.query.paired = true;
+
+            await searchUnpairedVeterans(req, res);
+
+            expect(res.status.calledWith(501)).to.be.true;
+            expect(res.json.calledOnce).to.be.true;
+            const response = res.json.firstCall.args[0];
+            expect(response.error).to.include('Not Implemented');
+            expect(response.error).to.include('paired=true');
+            expect(global.fetch.called).to.be.false;
+        });
+
+        it('should return 501 Not Implemented when paired="true" (string)', async () => {
+            req.query.paired = 'true';
+
+            await searchUnpairedVeterans(req, res);
+
+            expect(res.status.calledWith(501)).to.be.true;
+            expect(res.json.calledOnce).to.be.true;
+            const response = res.json.firstCall.args[0];
+            expect(response.error).to.include('Not Implemented');
+        });
+
+        it('should handle database errors', async () => {
+            global.fetch.rejects(new Error('Database connection error'));
+
+            await searchUnpairedVeterans(req, res);
+
+            expect(res.status.calledWith(500)).to.be.true;
+            expect(res.json.calledOnce).to.be.true;
+            const response = res.json.firstCall.args[0];
+            expect(response.error).to.equal('Database connection error');
+        });
+
+        it('should handle CouchDB error responses (4xx/5xx)', async () => {
+            global.fetch.resolves({
+                ok: false,
+                status: 404,
+                json: async () => ({ error: 'not_found', reason: 'View not found' })
+            });
+
+            await searchUnpairedVeterans(req, res);
+
+            expect(res.status.calledWith(500)).to.be.true;
+            expect(res.json.calledOnce).to.be.true;
+            const response = res.json.firstCall.args[0];
+            // data.reason takes priority over data.error, so it should be "View not found"
+            expect(response.error).to.include('View not found');
+        });
+
+        it('should handle CouchDB error responses without reason field', async () => {
+            global.fetch.resolves({
+                ok: false,
+                status: 500,
+                json: async () => ({ error: 'Internal server error' })
+            });
+
+            await searchUnpairedVeterans(req, res);
+
+            expect(res.status.calledWith(500)).to.be.true;
+            expect(res.json.calledOnce).to.be.true;
+            const response = res.json.firstCall.args[0];
+            expect(response.error).to.include('Internal server error');
+        });
+
+        it('should handle CouchDB error responses with reason field', async () => {
+            global.fetch.resolves({
+                ok: false,
+                status: 400,
+                json: async () => ({ reason: 'Invalid query parameters' })
+            });
+
+            await searchUnpairedVeterans(req, res);
+
+            expect(res.status.calledWith(500)).to.be.true;
+            expect(res.json.calledOnce).to.be.true;
+            const response = res.json.firstCall.args[0];
+            expect(response.error).to.include('Invalid query parameters');
+        });
+
+        it('should handle CouchDB error responses without reason or error fields', async () => {
+            global.fetch.resolves({
+                ok: false,
+                status: 500,
+                json: async () => ({})
+            });
+
+            await searchUnpairedVeterans(req, res);
+
+            expect(res.status.calledWith(500)).to.be.true;
+            expect(res.json.calledOnce).to.be.true;
+            const response = res.json.firstCall.args[0];
+            expect(response.error).to.equal('Failed to search unpaired veterans');
+        });
+
+        it('should handle empty results', async () => {
+            const mockDbResult = {
+                total_rows: 0,
+                offset: 0,
+                rows: []
+            };
+
+            global.fetch.resolves({
+                ok: true,
+                json: async () => mockDbResult
+            });
+
+            await searchUnpairedVeterans(req, res);
+
+            expect(res.json.calledOnce).to.be.true;
+            const response = res.json.firstCall.args[0];
+            expect(response).to.be.an('array').that.is.empty;
+        });
+
+        it('should use default values when query parameters are missing', async () => {
+            req.query = {};
+            const mockDbResult = {
+                total_rows: 0,
+                offset: 0,
+                rows: []
+            };
+
+            global.fetch.resolves({
+                ok: true,
+                json: async () => mockDbResult
+            });
+
+            await searchUnpairedVeterans(req, res);
+
+            expect(res.json.calledOnce).to.be.true;
+            // Verify fetch was called (defaults should be used)
+            expect(global.fetch.calledOnce).to.be.true;
+            const fetchUrl = global.fetch.firstCall.args[0];
+            expect(fetchUrl).to.include('unpaired_veterans_by_last_name');
+        });
+
+        it('should verify response structure matches emitted view format', async () => {
+            const mockDbResult = {
+                total_rows: 1,
+                offset: 0,
+                rows: [{
+                    id: 'doc1',
+                    key: ['Active', 'SMITH'],
+                    value: {
+                        name: 'John Smith',
+                        city: 'Chicago, IL',
+                        flight: 'F23',
+                        prefs: 'Prefers window seat'
+                    }
+                }]
+            };
+
+            global.fetch.resolves({
+                ok: true,
+                json: async () => mockDbResult
+            });
+
+            await searchUnpairedVeterans(req, res);
+
+            const response = res.json.firstCall.args[0];
+            
+            // Verify structure is a simple array with id, name, city, flight, prefs
+            expect(response).to.be.an('array');
+            expect(response).to.have.length(1);
+            expect(response[0]).to.have.property('id');
+            expect(response[0]).to.have.property('name');
+            expect(response[0]).to.have.property('city');
+            expect(response[0]).to.have.property('flight');
+            expect(response[0]).to.have.property('prefs');
+        });
+
+        it('should handle lastname with mixed case and convert to uppercase in query', async () => {
+            req.query.lastname = 'sMiTh';
+            const mockDbResult = {
+                total_rows: 1,
+                offset: 0,
+                rows: [{
+                    id: 'doc1',
+                    key: ['Active', 'SMITH'],
+                    value: {
+                        name: 'John Smith',
+                        city: 'Chicago, IL',
+                        flight: 'F23',
+                        prefs: ''
+                    }
+                }]
+            };
+
+            global.fetch.resolves({
+                ok: true,
+                json: async () => mockDbResult
+            });
+
+            await searchUnpairedVeterans(req, res);
+
+            expect(res.json.calledOnce).to.be.true;
+            // Verify the query was built correctly (lastname should be uppercased in the query)
+            expect(global.fetch.calledOnce).to.be.true;
+            const fetchUrl = global.fetch.firstCall.args[0];
+            // The URL should contain the uppercase version in the startkey
+            expect(fetchUrl).to.include('SMITH');
+        });
+
+        it('should handle different status values', async () => {
+            const statuses = ['Flown', 'Deceased', 'Removed', 'Future-Spring', 'Future-Fall', 'Future-PostRestriction'];
+            
+            for (const status of statuses) {
+                req.query.status = status;
+                const mockDbResult = {
+                    total_rows: 1,
+                    offset: 0,
+                    rows: [{
+                        id: 'doc1',
+                        key: [status, 'SMITH'],
+                        value: {
+                            name: 'John Smith',
+                            city: 'Chicago, IL',
+                            flight: 'F23',
+                            prefs: ''
+                        }
+                    }]
+                };
+
+                global.fetch.resolves({
+                    ok: true,
+                    json: async () => mockDbResult
+                });
+
+                await searchUnpairedVeterans(req, res);
+
+                const response = res.json.firstCall.args[0];
+                expect(response).to.be.an('array');
+                expect(response[0].id).to.equal('doc1');
+                
+                // Reset for next iteration
+                sinon.restore();
+                res.json = sinon.spy();
+                res.status = sinon.stub().returnsThis();
+                global.fetch = sinon.stub();
+            }
+        });
+    });
+});
+


### PR DESCRIPTION
Added search endpoint.
Only handles unpaired veterans.
Only returns matching results, not the continued extras like the search screen.