### PR TITLE
Add a caller section property for how you heard about SSHF

### DIFF
--- a/models/guardian.js
+++ b/models/guardian.js
@@ -118,6 +118,7 @@ export class Guardian {
             notes: data.call?.notes || '',
             email_sent: data.call?.email_sent || false,
             assigned_to: data.call?.assigned_to || '',
+            how_heard_about: data.call?.how_heard_about || 'Unknown',
             mail_sent: data.call?.mail_sent || false,
             history: data.call?.history || []
         };
@@ -244,6 +245,15 @@ export class Guardian {
                     errors.push(`Call history entry ${index + 1} must have a change description`);
                 }
             });
+        }
+        const validHowHeardAbout = [
+            'Unknown', 'VA or vet org', 'radio segment', 'tv interview or segment',
+            'school or community event', 'an SSHF event or fundraiser',
+            'newspaper or magazine ad or story', 'social media', 'family or friend',
+            'airport signage or experience', 'Kwik Trip Pump ad', 'other'
+        ];
+        if (this.call.how_heard_about && !validHowHeardAbout.includes(this.call.how_heard_about)) {
+            errors.push('Invalid how heard about value');
         }
 
         // Flight history entries validation
@@ -372,6 +382,7 @@ export class Guardian {
      * |------------------------|--------------------------|
      * | call.assigned_to       | assigned caller          |
      * | call.fm_number         | FM #                     |
+     * | call.how_heard_about   | how heard about          |
      * | call.email_sent        | guardian email sent      |
      * 
      * veteran.history tracks pairing changes (handled in routes/guardians.js):
@@ -419,6 +430,7 @@ export class Guardian {
                 'trackedProperties': [
                     { 'property': 'call.assigned_to', 'name': 'assigned caller' },
                     { 'property': 'call.fm_number', 'name': 'FM #' },
+                    { 'property': 'call.how_heard_about', 'name': 'how heard about' },
                     { 'property': 'call.email_sent', 'name': 'guardian email sent' }
                 ]
             }

--- a/models/veteran.js
+++ b/models/veteran.js
@@ -140,6 +140,7 @@ export class Veteran {
             notes: data.call?.notes || '',
             email_sent: data.call?.email_sent || false,
             assigned_to: data.call?.assigned_to || '',
+            how_heard_about: data.call?.how_heard_about || 'Unknown',
             mail_sent: data.call?.mail_sent || false,
             history: data.call?.history || []
         };
@@ -289,6 +290,15 @@ export class Veteran {
                 }
             });
         }
+        const validHowHeardAbout = [
+            'Unknown', 'VA or vet org', 'radio segment', 'tv interview or segment',
+            'school or community event', 'an SSHF event or fundraiser',
+            'newspaper or magazine ad or story', 'social media', 'family or friend',
+            'airport signage or experience', 'Kwik Trip Pump ad', 'other'
+        ];
+        if (this.call.how_heard_about && !validHowHeardAbout.includes(this.call.how_heard_about)) {
+            errors.push('Invalid how heard about value');
+        }
 
         // Gender validation
         if (this.gender && !['M', 'F'].includes(this.gender)) {
@@ -387,6 +397,7 @@ export class Veteran {
      * |------------------------|--------------------------|
      * | call.assigned_to       | assigned caller          |
      * | call.fm_number         | FM #                     |
+     * | call.how_heard_about   | how heard about          |
      * | call.mail_sent         | veteran mail sent        |
      * | call.email_sent        | mail call email sent     |
      * | mail_call.received     | mail call received       |
@@ -432,6 +443,7 @@ export class Veteran {
                 'trackedProperties': [
                     { 'property': 'call.assigned_to', 'name': 'assigned caller' },
                     { 'property': 'call.fm_number', 'name': 'FM #' },
+                    { 'property': 'call.how_heard_about', 'name': 'how heard about' },
                     { 'property': 'call.mail_sent', 'name': 'veteran mail sent' },
                     { 'property': 'call.email_sent', 'name': 'mail call email sent' },
                     { 'property': 'mail_call.received', 'name': 'mail call received' },

--- a/schemas/Guardian.yaml
+++ b/schemas/Guardian.yaml
@@ -457,6 +457,14 @@ properties:
         x-historyTracked:
           historyArray: 'call.history'
           displayName: 'assigned caller'
+      how_heard_about:
+        type: string
+        default: 'Unknown'
+        enum: ['Unknown', 'VA or vet org', 'radio segment', 'tv interview or segment', 'school or community event', 'an SSHF event or fundraiser', 'newspaper or magazine ad or story', 'social media', 'family or friend', 'airport signage or experience', 'Kwik Trip Pump ad', 'other']
+        description: 'How the guardian heard about the program. Changes are recorded in call.history.'
+        x-historyTracked:
+          historyArray: 'call.history'
+          displayName: 'how heard about'
       mail_sent:
         type: boolean
         default: false
@@ -475,7 +483,7 @@ properties:
               description: 'Description of what changed'
         description: >
           History of changes to call-related fields.
-          Records changes to: call.assigned_to, call.fm_number, call.email_sent.
+          Records changes to: call.assigned_to, call.fm_number, call.how_heard_about, call.email_sent.
   apparel:
     type: object
     properties:

--- a/schemas/Veteran.yaml
+++ b/schemas/Veteran.yaml
@@ -500,6 +500,14 @@ properties:
         x-historyTracked:
           historyArray: 'call.history'
           displayName: 'assigned caller'
+      how_heard_about:
+        type: string
+        default: 'Unknown'
+        enum: ['Unknown', 'VA or vet org', 'radio segment', 'tv interview or segment', 'school or community event', 'an SSHF event or fundraiser', 'newspaper or magazine ad or story', 'social media', 'family or friend', 'airport signage or experience', 'Kwik Trip Pump ad', 'other']
+        description: 'How the veteran heard about the program. Changes are recorded in call.history.'
+        x-historyTracked:
+          historyArray: 'call.history'
+          displayName: 'how heard about'
       mail_sent:
         type: boolean
         default: false
@@ -521,7 +529,7 @@ properties:
               description: 'Description of what changed'
         description: >
           History of changes to call-related fields.
-          Records changes to: call.assigned_to, call.fm_number, call.mail_sent,
+          Records changes to: call.assigned_to, call.fm_number, call.how_heard_about, call.mail_sent,
           call.email_sent, mail_call.received, mail_call.adopt.
   homecoming:
     type: object

--- a/test/guardian.test.js
+++ b/test/guardian.test.js
@@ -185,6 +185,7 @@ describe('Guardian Model', () => {
             expect(guardian.call.notes).to.equal('');
             expect(guardian.call.email_sent).to.be.false;
             expect(guardian.call.assigned_to).to.equal('');
+            expect(guardian.call.how_heard_about).to.equal('Unknown');
             expect(guardian.call.mail_sent).to.be.false;
             expect(guardian.call.history).to.be.an('array').that.is.empty;
         });
@@ -272,6 +273,7 @@ describe('Guardian Model', () => {
                     notes: 'Call in evening',
                     email_sent: true,
                     assigned_to: 'Jane Smith',
+                    how_heard_about: 'social media',
                     mail_sent: true,
                     history: [{ id: '2024-01-01T12:00:00Z', change: 'Initial call' }]
                 },
@@ -321,6 +323,7 @@ describe('Guardian Model', () => {
             expect(guardian.call.notes).to.equal('Call in evening');
             expect(guardian.call.email_sent).to.be.true;
             expect(guardian.call.assigned_to).to.equal('Jane Smith');
+            expect(guardian.call.how_heard_about).to.equal('social media');
             expect(guardian.call.mail_sent).to.be.true;
             expect(guardian.call.history).to.deep.equal([{ 
                 id: '2024-01-01T12:00:00Z', 
@@ -582,6 +585,24 @@ describe('Guardian Model', () => {
             const validRestrictions = ['None', 'Gluten Free', 'Vegetarian', 'Vegan'];
             validRestrictions.forEach(restriction => {
                 guardian.medical.food_restriction = restriction;
+                expect(() => guardian.validate()).to.not.throw();
+            });
+        });
+
+        it('should validate how heard about values', () => {
+            const guardian = new Guardian(sampleGuardianData);
+
+            guardian.call.how_heard_about = 'invalid-source';
+            expect(() => guardian.validate()).to.throw('Invalid how heard about value');
+
+            const validHowHeardAbout = [
+                'Unknown', 'VA or vet org', 'radio segment', 'tv interview or segment',
+                'school or community event', 'an SSHF event or fundraiser',
+                'newspaper or magazine ad or story', 'social media', 'family or friend',
+                'airport signage or experience', 'Kwik Trip Pump ad', 'other'
+            ];
+            validHowHeardAbout.forEach((source) => {
+                guardian.call.how_heard_about = source;
                 expect(() => guardian.validate()).to.not.throw();
             });
         });
@@ -1193,6 +1214,18 @@ describe('Guardian Model', () => {
             
             expect(newGuardian.call.history).to.have.lengthOf(1);
             expect(newGuardian.call.history[0].change).to.include('changed assigned caller from:  to: John Smith by: Admin User');
+        });
+
+        it('should track how heard about changes', () => {
+            const currentGuardian = new Guardian(sampleGuardianData);
+            const newGuardian = new Guardian(sampleGuardianData);
+            newGuardian.call.how_heard_about = 'family or friend';
+
+            const user = { firstName: 'Admin', lastName: 'User' };
+            newGuardian.updateHistory(currentGuardian, user);
+
+            expect(newGuardian.call.history).to.have.lengthOf(1);
+            expect(newGuardian.call.history[0].change).to.include('changed how heard about from: Unknown to: family or friend by: Admin User');
         });
 
         it('should track multiple changes', () => {

--- a/test/veteran.test.js
+++ b/test/veteran.test.js
@@ -203,6 +203,7 @@ describe('Veteran Model', () => {
             expect(veteran.call.notes).to.equal('');
             expect(veteran.call.email_sent).to.be.false;
             expect(veteran.call.assigned_to).to.equal('');
+            expect(veteran.call.how_heard_about).to.equal('Unknown');
             expect(veteran.call.mail_sent).to.be.false;
             expect(veteran.call.history).to.be.an('array').that.is.empty;
 
@@ -645,7 +646,8 @@ describe('Veteran Model', () => {
             const veteran = new Veteran({
                 call: {
                     fm_number: 'FM123',
-                    notes: 'Test notes'
+                    notes: 'Test notes',
+                    how_heard_about: 'social media'
                     // other fields missing
                 }
             });
@@ -653,6 +655,7 @@ describe('Veteran Model', () => {
             // Verify defined values are kept and missing ones get defaults
             expect(veteran.call.fm_number).to.equal('FM123');
             expect(veteran.call.notes).to.equal('Test notes');
+            expect(veteran.call.how_heard_about).to.equal('social media');
             expect(veteran.call.email_sent).to.be.false;
             expect(veteran.call.assigned_to).to.equal('');
             expect(veteran.call.mail_sent).to.be.false;
@@ -1490,6 +1493,24 @@ describe('Veteran Model', () => {
             veteran.medical.food_restriction = '';
             expect(() => veteran.validate()).to.not.throw();
         });
+
+        it('should validate how heard about values', () => {
+            const veteran = new Veteran(sampleVeteranData);
+
+            veteran.call.how_heard_about = 'invalid-source';
+            expect(() => veteran.validate()).to.throw('Invalid how heard about value');
+
+            const validHowHeardAbout = [
+                'Unknown', 'VA or vet org', 'radio segment', 'tv interview or segment',
+                'school or community event', 'an SSHF event or fundraiser',
+                'newspaper or magazine ad or story', 'social media', 'family or friend',
+                'airport signage or experience', 'Kwik Trip Pump ad', 'other'
+            ];
+            validHowHeardAbout.forEach((source) => {
+                veteran.call.how_heard_about = source;
+                expect(() => veteran.validate()).to.not.throw();
+            });
+        });
     });
 
     describe('prepareForSave', () => {
@@ -1537,6 +1558,18 @@ describe('Veteran Model', () => {
             
             expect(newVeteran.call.history).to.have.lengthOf(1);
             expect(newVeteran.call.history[0].change).to.include('changed mail call received');
+        });
+
+        it('should track how heard about changes', () => {
+            const currentVeteran = new Veteran(sampleVeteranData);
+            const newVeteran = new Veteran(sampleVeteranData);
+            newVeteran.call.how_heard_about = 'family or friend';
+
+            const user = { firstName: 'Admin', lastName: 'User' };
+            newVeteran.updateHistory(currentVeteran, user);
+
+            expect(newVeteran.call.history).to.have.lengthOf(1);
+            expect(newVeteran.call.history[0].change).to.include('changed how heard about from Unknown to family or friend by: Admin User');
         });
     });
 


### PR DESCRIPTION
# Add `how_heard_about` Property to Guardian and Veteran

## Reference: Commit f891cb5

From [commit f891cb5](https://github.com/shmakes/hf-basic/commit/f891cb533891f9e8b502f0d2fb6ea9a377bdb480), the `how_heard_about` field is added inside the `call` object for both guardians and veterans. It is a string enum with these valid values:

- `"Unknown"` (default)
- `"VA or vet org"`
- `"radio segment"`
- `"tv interview or segment"`
- `"school or community event"`
- `"an SSHF event or fundraiser"`
- `"newspaper or magazine ad or story"`
- `"social media"`
- `"family or friend"`
- `"airport signage or experience"`
- `"Kwik Trip Pump ad"`
- `"other"`

## Why Routes Don't Need Code Changes

The route controllers ([routes/guardians.js](routes/guardians.js), [routes/veterans.js](routes/veterans.js)) already handle the `call` object generically:

- **Create**: `new Guardian(req.body)` / `new Veteran(req.body)` -- constructor picks up the new field automatically
- **Retrieve**: `fromJSON(data)` -- passes through the constructor, which initializes the field
- **Update**: `new Guardian({...req.body, ...})` -- constructor picks up the field; `updateHistory()` tracks changes via the mapping table
- **Delete / Seat / Bus patches**: no model-level changes needed

All Swagger docs reference `$ref: '#/components/schemas/Guardian'` / `Veteran`, so updating the YAML schemas covers the API documentation.

---

## 1. Model: [models/guardian.js](models/guardian.js)

### Constructor (line 116-123)

Add `how_heard_about` to the `call` object:

```javascript
this.call = {
    fm_number: data.call?.fm_number || '',
    notes: data.call?.notes || '',
    email_sent: data.call?.email_sent || false,
    assigned_to: data.call?.assigned_to || '',
    how_heard_about: data.call?.how_heard_about || 'Unknown',  // NEW
    mail_sent: data.call?.mail_sent || false,
    history: data.call?.history || []
};
```

### Validation (inside `validate()`, after call history validation ~line 247)

Add enum validation:

```javascript
const VALID_HOW_HEARD_ABOUT = [
    'Unknown', 'VA or vet org', 'radio segment', 'tv interview or segment',
    'school or community event', 'an SSHF event or fundraiser',
    'newspaper or magazine ad or story', 'social media', 'family or friend',
    'airport signage or experience', 'Kwik Trip Pump ad', 'other'
];
if (this.call.how_heard_about && !VALID_HOW_HEARD_ABOUT.includes(this.call.how_heard_about)) {
    errors.push('Invalid how heard about value');
}
```

### History tracking (inside `updateHistory()`, line 417-424)

Add to the `call.history` tracked properties:

```javascript
{ 'property': 'call.how_heard_about', 'name': 'how heard about' }
```

### History tracking documentation (JSDoc table, ~line 369-376)

Add row to the `call.history tracks changes to` table:

```
 * | call.how_heard_about   | how heard about          |
```

---

## 2. Model: [models/veteran.js](models/veteran.js)

Identical pattern to Guardian -- same three locations:

### Constructor (line 138-145)

Add `how_heard_about: data.call?.how_heard_about || 'Unknown'` to the `call` object.

### Validation (after call history validation ~line 291)

Same enum validation as Guardian.

### History tracking (line 430-440)

Add `{ 'property': 'call.how_heard_about', 'name': 'how heard about' }` to the `call.history` tracked properties.

### History tracking documentation (JSDoc table, ~line 385-394)

Add row to the `call.history tracks changes to` table.

---

## 3. OpenAPI Schemas

### [schemas/Guardian.yaml](schemas/Guardian.yaml) (inside `call.properties`, ~line 437)

Add after `assigned_to`:

```yaml
      how_heard_about:
        type: string
        default: 'Unknown'
        enum: ['Unknown', 'VA or vet org', 'radio segment', 'tv interview or segment', 'school or community event', 'an SSHF event or fundraiser', 'newspaper or magazine ad or story', 'social media', 'family or friend', 'airport signage or experience', 'Kwik Trip Pump ad', 'other']
        description: 'How the guardian heard about the program. Changes are recorded in call.history.'
        x-historyTracked:
          historyArray: 'call.history'
          displayName: 'how heard about'
```

Also update the `call.history` description to list `call.how_heard_about`.

### [schemas/Veteran.yaml](schemas/Veteran.yaml) (inside `call.properties`, ~line 478)

Same addition as Guardian, plus update history description.

---

## 4. Tests

### [test/guardian.test.js](test/guardian.test.js)

- **Constructor defaults test** (~line 179): add `expect(guardian.call.how_heard_about).to.equal('Unknown');`
- **Constructor with provided values test** (~line 240): add `how_heard_about: 'social media'` to the call data and assert it
- **New validation test**: validate valid and invalid `how_heard_about` values
- **History tracking test**: verify that changing `how_heard_about` creates a `call.history` entry

### [test/veteran.test.js](test/veteran.test.js)

- **Constructor defaults test** (~line 197): add `expect(veteran.call.how_heard_about).to.equal('Unknown');`
- **Constructor with provided values**: add `how_heard_about` to partially-defined call tests
- **New validation test**: validate valid and invalid `how_heard_about` values
- **History tracking test**: verify that changing `how_heard_about` creates a `call.history` entry

### Route tests ([test/guardians.test.js](test/guardians.test.js), [test/veterans.test.js](test/veterans.test.js))

- No structural changes needed since routes are unchanged, but verify existing tests pass with the new field default