### PR TITLE
52 add flight detail fields for other edit forms

### DIFF
--- a/.cursor/index.mdc
+++ b/.cursor/index.mdc
@@ -1,4 +1,10 @@
+---
+alwaysApply: true
+---
+
 This API will be hosted on Google Cloud using Cloud Run.
 It will provide user authentication using Google domain accounts and then interact with a CouchDB REST database.
 The API will receive requests with JSON payload and respond with JSON.
 Always use ES module style JavaScript syntax.
+
+For rule grouping and conflict precedence, see `.cursor/rules/index.mdc`.

--- a/.cursor/rules/api-contract-consistency.mdc
+++ b/.cursor/rules/api-contract-consistency.mdc
@@ -1,0 +1,29 @@
+---
+description: Enforce consistent JSON request and response contracts across API routes
+globs: ["index.js", "routes/**/*.js", "models/**/*.js", "swagger/**/*.js", "schemas/**/*.yaml", "test/**/*.js"]
+alwaysApply: true
+---
+
+# API contract consistency workflow
+
+For any endpoint change, keep request and response contracts consistent across routes, models, tests, and docs.
+
+1. Keep the API JSON-only for request and response payloads.
+2. Use explicit HTTP status codes for success and error paths.
+3. Use a consistent error payload shape for all route handlers.
+4. Validate or normalize input before database writes.
+5. Return stable field names and types for successful responses.
+6. Keep route behavior, tests, and OpenAPI docs aligned in the same change.
+
+## Response shape expectations
+
+- Prefer one shared success pattern per endpoint type and keep it stable over time
+- Prefer one shared error pattern project-wide (for example, a single top-level error key)
+- Do not mix response shapes for similar failures across resources
+- Include enough context in error messages for client handling without exposing internals
+
+## Guardrails
+
+- Do not silently change status codes or payload keys without updating tests and OpenAPI
+- Do not return HTML or plain text from API endpoints unless explicitly required
+- Do not add new route-level response conventions that conflict with existing ones

--- a/.cursor/rules/auth-middleware-order.mdc
+++ b/.cursor/rules/auth-middleware-order.mdc
@@ -1,0 +1,27 @@
+---
+description: Enforce consistent middleware ordering for protected API routes
+globs: ["index.js", "routes/**/*.js", "test/**/*.js"]
+alwaysApply: true
+---
+
+# Auth and middleware order workflow
+
+For protected endpoints, keep middleware ordering predictable so authentication and DB session behavior stays consistent.
+
+1. Apply `authenticate` before any protected route handler.
+2. Apply `dbSession` before handlers that call CouchDB.
+3. Keep middleware order in `index.js` consistent with existing endpoint patterns.
+4. Verify tests cover unauthorized access and authenticated success paths.
+5. Keep public endpoints explicitly defined as public and avoid accidental exposure.
+
+## Protected route expectations
+
+- Protected routes should not execute business logic before auth checks
+- Database routes should not attempt CouchDB access before `dbSession` sets request context
+- Any new middleware should preserve existing auth and db guarantees
+
+## Guardrails
+
+- Do not reorder middleware in ways that bypass authentication
+- Do not add new protected routes without auth tests
+- Do not treat route protection as implicit; middleware must be explicit in route registration

--- a/.cursor/rules/config-and-script-consistency.mdc
+++ b/.cursor/rules/config-and-script-consistency.mdc
@@ -1,0 +1,27 @@
+---
+description: Keep package scripts, coverage config, and docs aligned with repository structure
+globs: ["package.json", "package-lock.json", "README.md", "index.js", "routes/**/*.js", "models/**/*.js", "test/**/*.js"]
+alwaysApply: true
+---
+
+# Config and script consistency workflow
+
+When project structure or test scope changes, keep scripts and configuration aligned in the same change.
+
+1. Update `package.json` scripts when test commands or workflows change.
+2. Keep coverage include paths aligned with real source layout.
+3. Keep dependency and audit scripts functional after structural changes.
+4. Update README setup, test, and coverage instructions when commands change.
+5. Re-run relevant scripts after config changes and confirm expected behavior.
+
+## Configuration expectations
+
+- Runtime behavior and documented commands should remain in sync
+- New required environment variables should be documented with purpose
+- Dependency updates should follow the repo's existing verify flow
+
+## Guardrails
+
+- Do not leave stale scripts that target removed paths
+- Do not change test or coverage commands without updating README guidance
+- Do not edit lockfile manually; use package manager commands

--- a/.cursor/rules/couchdb-access-guardrails.mdc
+++ b/.cursor/rules/couchdb-access-guardrails.mdc
@@ -1,0 +1,27 @@
+---
+description: Standardize CouchDB access through shared session and fetch utilities
+globs: ["utils/db.js", "routes/**/*.js", "test/**/*.js"]
+alwaysApply: true
+---
+
+# CouchDB access workflow
+
+For any database interaction, use the shared CouchDB session and fetch patterns already established in this repository.
+
+1. Route handlers that call CouchDB should run behind `dbSession` middleware.
+2. Use `dbFetch` for CouchDB requests instead of direct `fetch` calls from routes.
+3. Preserve retry and session-refresh behavior implemented in `utils/db.js`.
+4. Handle `DatabaseSessionError` consistently with `503` responses.
+5. Keep CouchDB URL construction predictable and centralized by using `DB_URL` and `DB_NAME`.
+
+## Session and error expectations
+
+- Maintain auth/session cookie handling in shared utilities, not duplicated in route files
+- Keep database request headers consistent (`Accept`, JSON content type where needed)
+- Return route-specific errors for expected failures (for example 404) and standardized server errors otherwise
+
+## Guardrails
+
+- Do not bypass `dbFetch` in route handlers unless there is a documented exception
+- Do not add per-route custom session caches that duplicate `utils/db.js`
+- Do not leak raw CouchDB credentials or cookie values in logs or responses

--- a/.cursor/rules/index.mdc
+++ b/.cursor/rules/index.mdc
@@ -1,0 +1,48 @@
+---
+description: Index and precedence guide for repository rule files
+globs: ["**/*"]
+alwaysApply: true
+---
+
+# Rules index and precedence
+
+This file explains how repository rules in `.cursor/rules/` work together.
+
+## Baseline location
+
+Keep `.cursor/index.mdc` in the parent `.cursor` folder.
+
+It is the global baseline for this project and defines high-level environment constraints:
+
+- Cloud Run hosting context
+- Google domain authentication context
+- CouchDB REST integration context
+- JSON API and ES module requirements
+
+Do not duplicate that baseline text in each rule file.
+
+## How rules work together
+
+Use `.cursor/index.mdc` for project-wide foundation and use files in `.cursor/rules/` for focused behavior guardrails.
+
+- `test-first-planning.mdc` defines plan-first and test-first execution flow
+- API contract and OpenAPI rules keep behavior and documentation aligned
+- Route/model and naming rules keep repository organization consistent
+- Auth and CouchDB rules enforce middleware and data access patterns
+- Config and security rules protect operational consistency and secrets hygiene
+
+## Conflict precedence guidance
+
+When guidance overlaps, apply rules in this order:
+
+1. Follow explicit user instructions first.
+2. Apply `.cursor/index.mdc` as the global project baseline.
+3. Apply `test-first-planning.mdc` for workflow and sequencing.
+4. Apply the most specific rule file for the touched area (auth, db, naming, docs, config, security).
+5. If two specific rules conflict, prefer the stricter guardrail and document the decision in your response.
+
+## Guardrails
+
+- Do not move `.cursor/index.mdc` into `.cursor/rules/` unless the team intentionally changes rule loading strategy.
+- Do not weaken stricter rule guidance to satisfy a looser rule.
+- If a rule becomes stale, update the rule file rather than silently bypassing it.

--- a/.cursor/rules/naming-conventions.mdc
+++ b/.cursor/rules/naming-conventions.mdc
@@ -1,0 +1,27 @@
+---
+description: Enforce naming conventions for routes, models, tests, and symbols
+globs: ["index.js", "routes/**/*.js", "models/**/*.js", "test/**/*.js", "swagger/**/*.js", "schemas/**/*.yaml", ".cursor/rules/*.mdc"]
+alwaysApply: true
+---
+
+# Naming conventions workflow
+
+For new files and symbols, follow existing naming patterns and avoid introducing mixed conventions.
+
+1. Keep route file names in kebab-case to match current route structure.
+2. Keep model file names in snake_case to match current model structure.
+3. Keep test file names aligned to target resource names with `.test.js` suffix.
+4. Keep exported functions descriptive and action-oriented (`create`, `retrieve`, `update`, `delete`, `list`, `search`, `get`).
+5. Keep environment variable names uppercase with underscores.
+
+## Consistency expectations
+
+- Prefer extending existing naming patterns over introducing new variants
+- When touching related files, opportunistically reduce obvious naming drift
+- Keep endpoint path naming and file naming logically aligned
+
+## Guardrails
+
+- Do not introduce mixed casing styles in the same directory
+- Do not add duplicate test files that differ only by separator style (`-` vs `_`) unless migration work is intentional
+- Do not rename established public endpoints without explicit request and migration notes

--- a/.cursor/rules/openapi-sync-rule.mdc
+++ b/.cursor/rules/openapi-sync-rule.mdc
@@ -1,0 +1,27 @@
+---
+description: Keep OpenAPI documentation synchronized with route and model behavior
+globs: ["routes/**/*.js", "models/**/*.js", "swagger/**/*.js", "schemas/**/*.yaml", "test/**/*.js", "README.md"]
+alwaysApply: true
+---
+
+# OpenAPI sync workflow
+
+When endpoint behavior changes, update API documentation in the same task so docs remain reliable.
+
+1. Update Swagger/OpenAPI annotations for changed routes.
+2. Update schema definitions when request or response fields change.
+3. Keep documented status codes aligned with real route behavior.
+4. Add or update tests that assert key contract behavior.
+5. Ensure examples and endpoint descriptions reflect the implemented behavior.
+
+## Documentation expectations
+
+- Endpoint paths, parameters, and security requirements should match route registration
+- Schema required fields and enums should match model validation rules
+- Success and error payload documentation should match route responses
+
+## Guardrails
+
+- Do not merge endpoint changes with stale OpenAPI docs
+- Do not document behavior that is not implemented
+- Do not change docs only; docs and code should move together for behavior changes

--- a/.cursor/rules/route-model-pairing.mdc
+++ b/.cursor/rules/route-model-pairing.mdc
@@ -1,0 +1,28 @@
+---
+description: Keep route handlers, models, tests, and documentation aligned per resource
+globs: ["index.js", "routes/**/*.js", "models/**/*.js", "test/**/*.js", "swagger/**/*.js", "schemas/**/*.yaml", "README.md"]
+alwaysApply: true
+---
+
+# Route-model pairing workflow
+
+For each API resource, maintain a clear and predictable pairing between route handlers, model logic, tests, and docs.
+
+1. Add or update route handlers in `routes/` for each endpoint change.
+2. Add or update the corresponding data model in `models/` when payload or validation rules change.
+3. Add or update tests in `test/` for every changed route or model behavior.
+4. Keep OpenAPI/Swagger docs updated for new or changed endpoints.
+5. Preserve the existing project structure and naming style used in this repository.
+
+## Resource change checklist
+
+- Route behavior matches model validation and serialization rules
+- Route files avoid embedding large validation rules that belong in model classes
+- Tests cover happy path, validation failures, and not-found/error paths
+- Docs reflect route parameters, request body shape, and response codes
+
+## Guardrails
+
+- Do not add new endpoints without tests
+- Do not add model fields without updating tests and docs
+- Do not bypass model validation in route handlers unless explicitly documented

--- a/.cursor/rules/security-and-secrets-hygiene.mdc
+++ b/.cursor/rules/security-and-secrets-hygiene.mdc
@@ -1,0 +1,27 @@
+---
+description: Protect credentials and enforce secure logging and auth handling patterns
+globs: ["index.js", "routes/**/*.js", "utils/**/*.js", "test/**/*.js", "README.md", "env.example"]
+alwaysApply: true
+---
+
+# Security and secrets hygiene workflow
+
+For authentication, database access, and configuration updates, follow secure handling patterns by default.
+
+1. Never commit credentials, tokens, private keys, or session cookies.
+2. Do not log secrets from headers, environment variables, or database auth artifacts.
+3. Keep authentication and authorization checks explicit on protected routes.
+4. Use environment variables for runtime secrets and keep sample config sanitized.
+5. Return safe error payloads that avoid leaking sensitive implementation details.
+
+## Security expectations
+
+- Cloud Run and local auth flows should use least-privilege scopes and explicit checks
+- Error logging should be actionable without exposing confidential values
+- Security-related behavior changes should include tests for unauthorized and forbidden flows
+
+## Guardrails
+
+- Do not print bearer tokens, service account private keys, or cookie values
+- Do not add fallback credentials directly in source files
+- Do not relax auth checks or CORS restrictions without explicit request and test coverage

--- a/.cursor/rules/test-first-planning.mdc
+++ b/.cursor/rules/test-first-planning.mdc
@@ -1,0 +1,50 @@
+---
+description: Enforce planning and test-first implementation for all feature work
+globs: ["**/*"]
+alwaysApply: true
+---
+
+# Plan-first, test-first workflow
+
+For any new feature, bug fix, refactor, or behavior change, follow this workflow by default:
+
+1. Start with a short implementation plan before making code changes.
+2. In the plan, identify:
+   - files likely to change
+   - test files to add or update
+   - acceptance criteria
+   - risks or edge cases
+3. Prefer creating tests first before implementation.
+4. Do not write production implementation code until tests or specs are written.
+5. After writing tests, run or describe running them and confirm they fail for the expected reason.
+6. Only after failing tests are established, implement the production code.
+7. Do not weaken, remove, or rewrite tests just to make implementation pass unless the user asks.
+8. After implementation, run the relevant tests again and confirm they pass.
+9. When possible, summarize work in this order:
+   - Plan
+   - Tests added/changed
+   - Implementation changed
+   - Verification results
+
+## Planning format
+
+When starting work, produce a concise plan like:
+
+- Goal
+- Files to inspect
+- Tests to create/update first
+- Implementation steps after tests fail
+- Validation steps
+
+## Test-first expectations
+
+- Prefer focused unit or integration tests over broad mocks
+- Reuse existing test patterns in the repository
+- Cover happy path, edge cases, and regression cases relevant to the change
+- If no test framework exists, say so explicitly and propose the smallest viable test approach before implementing
+
+## Guardrails
+
+- Never skip straight to implementation unless the user explicitly says to bypass planning or tests
+- If the task is too small for a formal plan, still give a one-to-three bullet mini-plan and note the tests first
+- If the codebase cannot support tests yet, explain the constraint and propose test scaffolding as the first step

--- a/README.md
+++ b/README.md
@@ -98,6 +98,34 @@ Interactive API documentation is available at `/api-docs` when the server is run
 
 The OpenAPI specification can be accessed directly at `/openapi.json`.
 
+### Key Flight Detail Endpoints
+
+- `GET /flights/:id/detail`
+- `PATCH /veterans/:id/seat`
+- `PATCH /veterans/:id/bus`
+- `PATCH /veterans/:id/mail-call-received`
+- `PATCH /veterans/:id/mail-call-adopt`
+- `PATCH /veterans/:id/medical-form`
+- `PATCH /veterans/:id/medical-review`
+- `PATCH /veterans/:id/vaccinated`
+- `PATCH /veterans/:id/homecoming-destination`
+- `PATCH /veterans/:id/apparel-shirt-size`
+- `PATCH /veterans/:id/apparel-jacket-size`
+- `PATCH /veterans/:id/apparel-notes`
+- `PATCH /guardians/:id/seat`
+- `PATCH /guardians/:id/bus`
+- `PATCH /guardians/:id/training-notes`
+- `PATCH /guardians/:id/training-complete`
+- `PATCH /guardians/:id/waiver`
+- `PATCH /guardians/:id/training-see-doc`
+- `PATCH /guardians/:id/vaccinated`
+- `PATCH /guardians/:id/medical-form`
+- `PATCH /guardians/:id/paid`
+- `PATCH /guardians/:id/books-ordered`
+- `PATCH /guardians/:id/apparel-shirt-size`
+- `PATCH /guardians/:id/apparel-jacket-size`
+- `PATCH /guardians/:id/apparel-notes`
+
 ## Project Structure
 
 ```

--- a/index.js
+++ b/index.js
@@ -12,8 +12,43 @@ import { getSecureData } from './routes/secure.js';
 import { getHasGroup } from './routes/user.js';
 import { getSearch } from './routes/search.js';
 import { createDocument, retrieveDocument, updateDocument, deleteDocument } from './routes/docs.js';
-import { createVeteran, retrieveVeteran, updateVeteran, deleteVeteran, searchUnpairedVeterans, updateVeteranSeat, updateVeteranBus } from './routes/veterans.js';
-import { createGuardian, retrieveGuardian, updateGuardian, deleteGuardian, updateGuardianSeat, updateGuardianBus } from './routes/guardians.js';
+import {
+    createVeteran,
+    retrieveVeteran,
+    updateVeteran,
+    deleteVeteran,
+    searchUnpairedVeterans,
+    updateVeteranSeat,
+    updateVeteranBus,
+    updateVeteranMailCallReceived,
+    updateVeteranMailCallAdopt,
+    updateVeteranMedicalForm,
+    updateVeteranMedicalReview,
+    updateVeteranVaccinated,
+    updateVeteranHomecomingDestination,
+    updateVeteranApparelShirtSize,
+    updateVeteranApparelJacketSize,
+    updateVeteranApparelNotes
+} from './routes/veterans.js';
+import {
+    createGuardian,
+    retrieveGuardian,
+    updateGuardian,
+    deleteGuardian,
+    updateGuardianSeat,
+    updateGuardianBus,
+    updateGuardianTrainingNotes,
+    updateGuardianTrainingComplete,
+    updateGuardianWaiver,
+    updateGuardianTrainingSeeDoc,
+    updateGuardianVaccinated,
+    updateGuardianMedicalForm,
+    updateGuardianPaid,
+    updateGuardianBooksOrdered,
+    updateGuardianApparelShirtSize,
+    updateGuardianApparelJacketSize,
+    updateGuardianApparelNotes
+} from './routes/guardians.js';
 import { listFlights, createFlight, retrieveFlight, updateFlight } from './routes/flights.js';
 import { getFlightAssignments, addVeteransToFlight } from './routes/flight-assignments.js';
 import { getFlightDetail } from './routes/flight-detail.js';
@@ -72,6 +107,15 @@ app.get("/veterans/:id", authenticate, dbSession, retrieveVeteran);
 app.put("/veterans/:id", authenticate, dbSession, updateVeteran);
 app.patch("/veterans/:id/seat", authenticate, dbSession, updateVeteranSeat);
 app.patch("/veterans/:id/bus", authenticate, dbSession, updateVeteranBus);
+app.patch("/veterans/:id/mail-call-received", authenticate, dbSession, updateVeteranMailCallReceived);
+app.patch("/veterans/:id/mail-call-adopt", authenticate, dbSession, updateVeteranMailCallAdopt);
+app.patch("/veterans/:id/medical-form", authenticate, dbSession, updateVeteranMedicalForm);
+app.patch("/veterans/:id/medical-review", authenticate, dbSession, updateVeteranMedicalReview);
+app.patch("/veterans/:id/vaccinated", authenticate, dbSession, updateVeteranVaccinated);
+app.patch("/veterans/:id/homecoming-destination", authenticate, dbSession, updateVeteranHomecomingDestination);
+app.patch("/veterans/:id/apparel-shirt-size", authenticate, dbSession, updateVeteranApparelShirtSize);
+app.patch("/veterans/:id/apparel-jacket-size", authenticate, dbSession, updateVeteranApparelJacketSize);
+app.patch("/veterans/:id/apparel-notes", authenticate, dbSession, updateVeteranApparelNotes);
 app.delete("/veterans/:id", authenticate, dbSession, deleteVeteran);
 
 // Guardian-specific routes
@@ -80,6 +124,17 @@ app.get("/guardians/:id", authenticate, dbSession, retrieveGuardian);
 app.put("/guardians/:id", authenticate, dbSession, updateGuardian);
 app.patch("/guardians/:id/seat", authenticate, dbSession, updateGuardianSeat);
 app.patch("/guardians/:id/bus", authenticate, dbSession, updateGuardianBus);
+app.patch("/guardians/:id/training-notes", authenticate, dbSession, updateGuardianTrainingNotes);
+app.patch("/guardians/:id/training-complete", authenticate, dbSession, updateGuardianTrainingComplete);
+app.patch("/guardians/:id/waiver", authenticate, dbSession, updateGuardianWaiver);
+app.patch("/guardians/:id/training-see-doc", authenticate, dbSession, updateGuardianTrainingSeeDoc);
+app.patch("/guardians/:id/vaccinated", authenticate, dbSession, updateGuardianVaccinated);
+app.patch("/guardians/:id/medical-form", authenticate, dbSession, updateGuardianMedicalForm);
+app.patch("/guardians/:id/paid", authenticate, dbSession, updateGuardianPaid);
+app.patch("/guardians/:id/books-ordered", authenticate, dbSession, updateGuardianBooksOrdered);
+app.patch("/guardians/:id/apparel-shirt-size", authenticate, dbSession, updateGuardianApparelShirtSize);
+app.patch("/guardians/:id/apparel-jacket-size", authenticate, dbSession, updateGuardianApparelJacketSize);
+app.patch("/guardians/:id/apparel-notes", authenticate, dbSession, updateGuardianApparelNotes);
 app.delete("/guardians/:id", authenticate, dbSession, deleteGuardian);
 
 // Flight-specific routes

--- a/models/flight_detail.js
+++ b/models/flight_detail.js
@@ -47,6 +47,19 @@ function parseBoolean(value) {
 }
 
 /**
+ * Parses books ordered value to a safe integer.
+ * @param {any} value - books ordered value from doc
+ * @returns {number}
+ */
+function parseBooksOrdered(value) {
+    const numeric = Number(value);
+    if (Number.isInteger(numeric) && numeric >= 0) {
+        return numeric;
+    }
+    return 0;
+}
+
+/**
  * Normalizes bus value to a valid bus name or 'None'
  * @param {string} value - The bus value from the view
  * @returns {string}
@@ -67,7 +80,11 @@ export class FlightDetailPerson {
         this.id = data.id || '';
         this.name_first = data.name_first || '';
         this.name_last = data.name_last || '';
+        this.name_middle = data.name_middle || '';
+        this.birth_date = data.birth_date || '';
+        this.gender = data.gender || '';
         this.city = data.city || '';
+        this.phone_mbl = data.phone_mbl || '';
         this.bus = normalizeBus(data.bus);
         this.seat = data.seat || '';
         this.shirt = data.shirt || '';
@@ -75,11 +92,25 @@ export class FlightDetailPerson {
         this.assigned_to = data.assigned_to || '';
         this.nofly = parseNofly(data.nofly);
         this.confirmed = parseConfirmed(data.confirmed);
+        this.medical_form = parseBoolean(data.medical_form);
+        this.medical_level = data.medical_level || '';
+        this.flight_vaccinated = parseBoolean(data.flight_vaccinated);
+        this.apparel_shirt_size = data.apparel_shirt_size || '';
+        this.apparel_jacket_size = data.apparel_jacket_size || '';
+        this.apparel_notes = data.apparel_notes || '';
         
         // Veteran-specific fields
         if (data.type === 'Veteran') {
             this.med_limits = data.med_limits || '';
             this.group = data.group || '';
+            this.mail_call_received = parseBoolean(data.mail_call_received);
+            this.mail_call_adopt = parseBoolean(data.mail_call_adopt);
+            this.mail_call_notes = data.mail_call_notes || '';
+            this.medical_alt_level = data.medical_alt_level || '';
+            this.medical_limitations = data.medical_limitations || '';
+            this.medical_review = data.medical_review || '';
+            this.medical_requires_oxygen = parseBoolean(data.medical_requires_oxygen);
+            this.homecoming_destination = data.homecoming_destination || '';
         }
         
         // Guardian-specific fields
@@ -87,6 +118,11 @@ export class FlightDetailPerson {
             this.med_exprnc = data.med_exprnc || '';
             this.training = data.training || '';
             this.training_complete = parseBoolean(data.training_complete);
+            this.flight_training_notes = data.flight_training_notes || '';
+            this.flight_waiver = parseBoolean(data.flight_waiver);
+            this.flight_training_see_doc = parseBoolean(data.flight_training_see_doc);
+            this.flight_paid = parseBoolean(data.flight_paid);
+            this.flight_books_ordered = parseBooksOrdered(data.flight_books_ordered);
         }
     }
 
@@ -96,52 +132,101 @@ export class FlightDetailPerson {
             id: this.id,
             name_first: this.name_first,
             name_last: this.name_last,
+            name_middle: this.name_middle,
+            birth_date: this.birth_date,
+            gender: this.gender,
             city: this.city,
+            phone_mbl: this.phone_mbl,
             bus: this.bus,
             seat: this.seat,
             shirt: this.shirt,
             fm_number: this.fm_number,
             assigned_to: this.assigned_to,
             nofly: this.nofly,
-            confirmed: this.confirmed
+            confirmed: this.confirmed,
+            medical_form: this.medical_form,
+            medical_level: this.medical_level,
+            flight_vaccinated: this.flight_vaccinated,
+            apparel_shirt_size: this.apparel_shirt_size,
+            apparel_jacket_size: this.apparel_jacket_size,
+            apparel_notes: this.apparel_notes
         };
         
         // Include type-specific fields
         if (this.type === 'Veteran') {
             result.med_limits = this.med_limits;
             result.group = this.group;
+            result.mail_call_received = this.mail_call_received;
+            result.mail_call_adopt = this.mail_call_adopt;
+            result.mail_call_notes = this.mail_call_notes;
+            result.medical_alt_level = this.medical_alt_level;
+            result.medical_limitations = this.medical_limitations;
+            result.medical_review = this.medical_review;
+            result.medical_requires_oxygen = this.medical_requires_oxygen;
+            result.homecoming_destination = this.homecoming_destination;
         }
         
         if (this.type === 'Guardian') {
             result.med_exprnc = this.med_exprnc;
             result.training = this.training;
             result.training_complete = this.training_complete;
+            result.flight_training_notes = this.flight_training_notes;
+            result.flight_waiver = this.flight_waiver;
+            result.flight_training_see_doc = this.flight_training_see_doc;
+            result.flight_paid = this.flight_paid;
+            result.flight_books_ordered = this.flight_books_ordered;
         }
         
         return result;
     }
 
     static fromViewRow(row) {
+        const value = row?.value ? row.value : (row || {});
+        const doc = row?.doc || value.doc || {};
+
         return new FlightDetailPerson({
-            type: row.type || '',
-            id: row.id || '',
-            name_first: row.name_first || '',
-            name_last: row.name_last || '',
-            city: row.city || '',
-            bus: row.bus,
-            seat: row.seat || '',
-            shirt: row.shirt || '',
-            fm_number: row.fm_number || '',
-            assigned_to: row.assigned_to || '',
-            nofly: row.nofly,
-            confirmed: row.confirmed,
+            type: value.type || '',
+            id: value.id || '',
+            name_first: value.name_first || '',
+            name_last: value.name_last || '',
+            city: value.city || '',
+            bus: value.bus,
+            seat: value.seat || '',
+            shirt: value.shirt || '',
+            fm_number: value.fm_number || '',
+            assigned_to: value.assigned_to || '',
+            nofly: value.nofly,
+            confirmed: value.confirmed,
+            name_middle: doc.name?.middle || '',
+            birth_date: doc.birth_date || '',
+            gender: doc.gender || '',
+            phone_mbl: doc.address?.phone_mbl || '',
+            medical_form: doc.medical?.form,
+            medical_level: doc.medical?.level || '',
+            flight_vaccinated: doc.flight?.vaccinated,
+            apparel_shirt_size: doc.apparel?.shirt_size || '',
+            apparel_jacket_size: doc.apparel?.jacket_size || '',
+            apparel_notes: doc.apparel?.notes || '',
             // Veteran fields
-            med_limits: row.med_limits || '',
-            group: row.group || '',
+            med_limits: value.med_limits || '',
+            group: value.group || '',
+            mail_call_received: doc.mail_call?.received,
+            mail_call_adopt: doc.mail_call?.adopt,
+            mail_call_notes: doc.mail_call?.notes || '',
+            medical_alt_level: doc.medical?.alt_level || '',
+            medical_limitations: doc.medical?.limitations || '',
+            medical_review: doc.medical?.review || '',
+            medical_requires_oxygen: doc.medical?.requiresOxygen,
+            homecoming_destination: doc.homecoming?.destination || '',
             // Guardian fields
-            med_exprnc: row.med_exprnc || '',
-            training: row.training || '',
-            training_complete: row.training_complete
+            med_exprnc: value.med_exprnc || '',
+            training: value.training || '',
+            training_complete: value.training_complete,
+            flight_training_notes: doc.flight?.training_notes || '',
+            flight_waiver: doc.flight?.waiver,
+            flight_training_see_doc: doc.flight?.training_see_doc,
+            flight_paid: doc.flight?.paid,
+            flight_books_ordered: doc.flight?.booksOrdered
         });
     }
 }
@@ -333,7 +418,7 @@ export class FlightDetailResult {
             const value = row.value;
             personIdsOnFlight.add(value.id);
             
-            const person = FlightDetailPerson.fromViewRow(value);
+            const person = FlightDetailPerson.fromViewRow(row);
             const pairing = value.pairing && value.pairing.length > 0 ? value.pairing : null;
             
             if (value.type === 'Guardian') {

--- a/routes/flight-detail.js
+++ b/routes/flight-detail.js
@@ -18,6 +18,7 @@ const dbName = process.env.DB_NAME;
  *         - Flight counts (excludes nofly entries)
  *       - List of veteran-guardian pairs with seat/bus assignments
  *       - Per-person call-center fields such as fm_number and assigned_to when present
+ *       - Per-person form fields used by gt-checkin, medical, and other flight forms
  *       
  *       Each pair includes mismatch flags:
  *       - busMismatch: true if people in the pair have different bus assignments
@@ -78,7 +79,8 @@ export async function getFlightDetail(req, res) {
         const viewUrl = `${dbUrl}/${dbName}/_design/basic/_view/flight_pairings?` +
             `startkey=${encodeURIComponent(JSON.stringify([flightData.name]))}` +
             `&endkey=${encodeURIComponent(JSON.stringify([flightData.name + '\ufff0']))}` +
-            `&descending=false`;
+            `&descending=false` +
+            `&include_docs=true`;
 
         const viewResponse = await dbFetch(req, viewUrl, {
             headers: {

--- a/routes/guardians.js
+++ b/routes/guardians.js
@@ -830,4 +830,239 @@ export async function updateGuardianBus(req, res) {
         console.error('Error updating guardian bus:', error);
         res.status(500).json({ error: error.message });
     }
-} 
+}
+
+const VALID_GUARDIAN_APPAREL_SHIRT_SIZES = [
+    'None', 'WXS', 'WS', 'WM', 'WL', 'WXL', 'W2XL', 'W3XL', 'W4XL', 'W5XL',
+    'XS', 'S', 'M', 'L', 'XL', '2XL', '3XL', '4XL', '5XL'
+];
+const VALID_GUARDIAN_APPAREL_JACKET_SIZES = ['None', 'XS', 'S', 'M', 'L', 'XL', '2XL', '3XL', '4XL', '5XL'];
+
+function getNestedValue(obj, path) {
+    return path.split('.').reduce((acc, key) => (acc && key in acc ? acc[key] : undefined), obj);
+}
+
+function ensureNestedObject(obj, pathParts) {
+    let current = obj;
+    for (const part of pathParts) {
+        if (!current[part] || typeof current[part] !== 'object') {
+            current[part] = {};
+        }
+        current = current[part];
+    }
+}
+
+function setNestedValue(obj, path, value) {
+    const parts = path.split('.');
+    const leaf = parts.pop();
+    ensureNestedObject(obj, parts);
+    let current = obj;
+    for (const part of parts) {
+        current = current[part];
+    }
+    current[leaf] = value;
+}
+
+async function patchGuardianField(req, res, config) {
+    try {
+        const docId = req.params.id;
+        const { value } = req.body;
+        if (value === undefined || value === null) {
+            return res.status(400).json({ error: 'value is required' });
+        }
+        if (config.validate && !config.validate(value)) {
+            return res.status(400).json({ error: config.validationMessage });
+        }
+
+        const url = `${dbUrl}/${dbName}/${docId}`;
+        const getResponse = await dbFetch(req, url);
+        if (!getResponse.ok) {
+            if (getResponse.status === 404) {
+                return res.status(404).json({ error: 'Guardian not found' });
+            }
+            throw new Error('Failed to get guardian for update');
+        }
+        const doc = await getResponse.json();
+        if (doc.type !== 'Guardian') {
+            return res.status(400).json({ error: 'Document is not a guardian record' });
+        }
+
+        const oldValue = getNestedValue(doc, config.docPath);
+        setNestedValue(doc, config.docPath, value);
+
+        const userName = req.user.firstName + ' ' + req.user.lastName;
+        const timestamp = new Date().toISOString().split('.')[0] + 'Z';
+        const historyPath = 'flight.history';
+        const history = getNestedValue(doc, historyPath);
+        if (!Array.isArray(history)) {
+            setNestedValue(doc, historyPath, []);
+        }
+        getNestedValue(doc, historyPath).push({
+            id: timestamp,
+            change: `changed ${config.historyLabel} from: ${oldValue ?? ''} to: ${value} by: ${userName}`
+        });
+
+        if (!doc.metadata || typeof doc.metadata !== 'object') {
+            doc.metadata = {};
+        }
+        doc.metadata.updated_at = timestamp;
+        doc.metadata.updated_by = userName;
+
+        const updateResponse = await dbFetch(req, url, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(doc)
+        });
+        if (!updateResponse.ok) {
+            const data = await updateResponse.json();
+            throw new Error(data.reason || config.saveError);
+        }
+
+        const data = await updateResponse.json();
+        return res.json({
+            ok: true,
+            id: data.id,
+            rev: data.rev,
+            [config.responseField]: value
+        });
+    } catch (error) {
+        if (error instanceof DatabaseSessionError) {
+            console.error('Database session error:', error.message);
+            return res.status(503).json({ error: error.message });
+        }
+        console.error(`Error updating guardian ${config.errorLabel}:`, error);
+        return res.status(500).json({ error: error.message });
+    }
+}
+
+export async function updateGuardianTrainingNotes(req, res) {
+    return patchGuardianField(req, res, {
+        docPath: 'flight.training_notes',
+        responseField: 'training_notes',
+        historyLabel: 'training notes',
+        validate: (value) => typeof value === 'string',
+        validationMessage: 'value must be a string',
+        saveError: 'Failed to update guardian training notes',
+        errorLabel: 'training notes'
+    });
+}
+
+export async function updateGuardianTrainingComplete(req, res) {
+    return patchGuardianField(req, res, {
+        docPath: 'flight.training_complete',
+        responseField: 'training_complete',
+        historyLabel: 'training complete',
+        validate: (value) => typeof value === 'boolean',
+        validationMessage: 'value must be a boolean',
+        saveError: 'Failed to update guardian training complete',
+        errorLabel: 'training complete'
+    });
+}
+
+export async function updateGuardianWaiver(req, res) {
+    return patchGuardianField(req, res, {
+        docPath: 'flight.waiver',
+        responseField: 'waiver',
+        historyLabel: 'flight waiver received',
+        validate: (value) => typeof value === 'boolean',
+        validationMessage: 'value must be a boolean',
+        saveError: 'Failed to update guardian waiver',
+        errorLabel: 'waiver'
+    });
+}
+
+export async function updateGuardianTrainingSeeDoc(req, res) {
+    return patchGuardianField(req, res, {
+        docPath: 'flight.training_see_doc',
+        responseField: 'training_see_doc',
+        historyLabel: 'training see doctor',
+        validate: (value) => typeof value === 'boolean',
+        validationMessage: 'value must be a boolean',
+        saveError: 'Failed to update guardian training see doc',
+        errorLabel: 'training see doc'
+    });
+}
+
+export async function updateGuardianVaccinated(req, res) {
+    return patchGuardianField(req, res, {
+        docPath: 'flight.vaccinated',
+        responseField: 'vaccinated',
+        historyLabel: 'vaccinated',
+        validate: (value) => typeof value === 'boolean',
+        validationMessage: 'value must be a boolean',
+        saveError: 'Failed to update guardian vaccinated',
+        errorLabel: 'vaccinated'
+    });
+}
+
+export async function updateGuardianMedicalForm(req, res) {
+    return patchGuardianField(req, res, {
+        docPath: 'medical.form',
+        responseField: 'medical_form',
+        historyLabel: 'medical form received',
+        validate: (value) => typeof value === 'boolean',
+        validationMessage: 'value must be a boolean',
+        saveError: 'Failed to update guardian medical form',
+        errorLabel: 'medical form'
+    });
+}
+
+export async function updateGuardianPaid(req, res) {
+    return patchGuardianField(req, res, {
+        docPath: 'flight.paid',
+        responseField: 'paid',
+        historyLabel: 'paid',
+        validate: (value) => typeof value === 'boolean',
+        validationMessage: 'value must be a boolean',
+        saveError: 'Failed to update guardian paid',
+        errorLabel: 'paid'
+    });
+}
+
+export async function updateGuardianBooksOrdered(req, res) {
+    return patchGuardianField(req, res, {
+        docPath: 'flight.booksOrdered',
+        responseField: 'books_ordered',
+        historyLabel: 'books ordered',
+        validate: (value) => Number.isInteger(value) && value >= 0 && value <= 9,
+        validationMessage: 'value must be an integer between 0 and 9',
+        saveError: 'Failed to update guardian books ordered',
+        errorLabel: 'books ordered'
+    });
+}
+
+export async function updateGuardianApparelShirtSize(req, res) {
+    return patchGuardianField(req, res, {
+        docPath: 'apparel.shirt_size',
+        responseField: 'apparel_shirt_size',
+        historyLabel: 'apparel shirt size',
+        validate: (value) => typeof value === 'string' && VALID_GUARDIAN_APPAREL_SHIRT_SIZES.includes(value),
+        validationMessage: 'invalid apparel shirt size',
+        saveError: 'Failed to update guardian apparel shirt size',
+        errorLabel: 'apparel shirt size'
+    });
+}
+
+export async function updateGuardianApparelJacketSize(req, res) {
+    return patchGuardianField(req, res, {
+        docPath: 'apparel.jacket_size',
+        responseField: 'apparel_jacket_size',
+        historyLabel: 'apparel jacket size',
+        validate: (value) => typeof value === 'string' && VALID_GUARDIAN_APPAREL_JACKET_SIZES.includes(value),
+        validationMessage: 'invalid apparel jacket size',
+        saveError: 'Failed to update guardian apparel jacket size',
+        errorLabel: 'apparel jacket size'
+    });
+}
+
+export async function updateGuardianApparelNotes(req, res) {
+    return patchGuardianField(req, res, {
+        docPath: 'apparel.notes',
+        responseField: 'apparel_notes',
+        historyLabel: 'apparel notes',
+        validate: (value) => typeof value === 'string',
+        validationMessage: 'value must be a string',
+        saveError: 'Failed to update guardian apparel notes',
+        errorLabel: 'apparel notes'
+    });
+}

--- a/routes/veterans.js
+++ b/routes/veterans.js
@@ -756,4 +756,225 @@ export async function updateVeteranBus(req, res) {
         console.error('Error updating veteran bus:', error);
         res.status(500).json({ error: error.message });
     }
-} 
+}
+
+const VALID_VETERAN_APPAREL_SHIRT_SIZES = [
+    'None', 'WXS', 'WS', 'WM', 'WL', 'WXL', 'W2XL', 'W3XL', 'W4XL', 'W5XL',
+    'XS', 'S', 'M', 'L', 'XL', '2XL', '3XL', '4XL', '5XL'
+];
+const VALID_VETERAN_APPAREL_JACKET_SIZES = ['None', 'XS', 'S', 'M', 'L', 'XL', '2XL', '3XL', '4XL', '5XL'];
+const HOME_DESTINATION_REGEX = /^[a-zA-Z0-9 ]{0,30}$/;
+
+function getNestedValue(obj, path) {
+    return path.split('.').reduce((acc, key) => (acc && key in acc ? acc[key] : undefined), obj);
+}
+
+function ensureNestedObject(obj, pathParts) {
+    let current = obj;
+    for (const part of pathParts) {
+        if (!current[part] || typeof current[part] !== 'object') {
+            current[part] = {};
+        }
+        current = current[part];
+    }
+}
+
+function setNestedValue(obj, path, value) {
+    const parts = path.split('.');
+    const leaf = parts.pop();
+    ensureNestedObject(obj, parts);
+    let current = obj;
+    for (const part of parts) {
+        current = current[part];
+    }
+    current[leaf] = value;
+}
+
+async function patchVeteranField(req, res, config) {
+    try {
+        const docId = req.params.id;
+        const { value } = req.body;
+        if (value === undefined || value === null) {
+            return res.status(400).json({ error: 'value is required' });
+        }
+        if (config.validate && !config.validate(value)) {
+            return res.status(400).json({ error: config.validationMessage });
+        }
+
+        const url = `${dbUrl}/${dbName}/${docId}`;
+        const getResponse = await dbFetch(req, url);
+        if (!getResponse.ok) {
+            if (getResponse.status === 404) {
+                return res.status(404).json({ error: 'Veteran not found' });
+            }
+            throw new Error('Failed to get veteran for update');
+        }
+        const doc = await getResponse.json();
+        if (doc.type !== 'Veteran') {
+            return res.status(400).json({ error: 'Document is not a veteran record' });
+        }
+
+        const oldValue = getNestedValue(doc, config.docPath);
+        setNestedValue(doc, config.docPath, value);
+
+        const userName = req.user.firstName + ' ' + req.user.lastName;
+        const timestamp = new Date().toISOString().split('.')[0] + 'Z';
+        const historyPath = config.historyPath;
+        const history = getNestedValue(doc, historyPath);
+        if (!Array.isArray(history)) {
+            setNestedValue(doc, historyPath, []);
+        }
+        getNestedValue(doc, historyPath).push({
+            id: timestamp,
+            change: `changed ${config.historyLabel} from: ${oldValue ?? ''} to: ${value} by: ${userName}`
+        });
+
+        if (!doc.metadata || typeof doc.metadata !== 'object') {
+            doc.metadata = {};
+        }
+        doc.metadata.updated_at = timestamp;
+        doc.metadata.updated_by = userName;
+
+        const updateResponse = await dbFetch(req, url, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(doc)
+        });
+        if (!updateResponse.ok) {
+            const data = await updateResponse.json();
+            throw new Error(data.reason || config.saveError);
+        }
+
+        const data = await updateResponse.json();
+        return res.json({
+            ok: true,
+            id: data.id,
+            rev: data.rev,
+            [config.responseField]: value
+        });
+    } catch (error) {
+        if (error instanceof DatabaseSessionError) {
+            console.error('Database session error:', error.message);
+            return res.status(503).json({ error: error.message });
+        }
+        console.error(`Error updating veteran ${config.errorLabel}:`, error);
+        return res.status(500).json({ error: error.message });
+    }
+}
+
+export async function updateVeteranMailCallReceived(req, res) {
+    return patchVeteranField(req, res, {
+        docPath: 'mail_call.received',
+        responseField: 'mail_call_received',
+        historyPath: 'call.history',
+        historyLabel: 'mail call received',
+        validate: (value) => typeof value === 'boolean',
+        validationMessage: 'value must be a boolean',
+        saveError: 'Failed to update veteran mail call received',
+        errorLabel: 'mail call received'
+    });
+}
+
+export async function updateVeteranMailCallAdopt(req, res) {
+    return patchVeteranField(req, res, {
+        docPath: 'mail_call.adopt',
+        responseField: 'mail_call_adopt',
+        historyPath: 'call.history',
+        historyLabel: 'mail call adopt',
+        validate: (value) => typeof value === 'boolean',
+        validationMessage: 'value must be a boolean',
+        saveError: 'Failed to update veteran mail call adopt',
+        errorLabel: 'mail call adopt'
+    });
+}
+
+export async function updateVeteranMedicalForm(req, res) {
+    return patchVeteranField(req, res, {
+        docPath: 'medical.form',
+        responseField: 'medical_form',
+        historyPath: 'flight.history',
+        historyLabel: 'medical form received',
+        validate: (value) => typeof value === 'boolean',
+        validationMessage: 'value must be a boolean',
+        saveError: 'Failed to update veteran medical form',
+        errorLabel: 'medical form'
+    });
+}
+
+export async function updateVeteranMedicalReview(req, res) {
+    return patchVeteranField(req, res, {
+        docPath: 'medical.review',
+        responseField: 'medical_review',
+        historyPath: 'flight.history',
+        historyLabel: 'medical review',
+        validate: (value) => typeof value === 'string',
+        validationMessage: 'value must be a string',
+        saveError: 'Failed to update veteran medical review',
+        errorLabel: 'medical review'
+    });
+}
+
+export async function updateVeteranVaccinated(req, res) {
+    return patchVeteranField(req, res, {
+        docPath: 'flight.vaccinated',
+        responseField: 'flight_vaccinated',
+        historyPath: 'flight.history',
+        historyLabel: 'vaccinated',
+        validate: (value) => typeof value === 'boolean',
+        validationMessage: 'value must be a boolean',
+        saveError: 'Failed to update veteran vaccinated',
+        errorLabel: 'vaccinated'
+    });
+}
+
+export async function updateVeteranHomecomingDestination(req, res) {
+    return patchVeteranField(req, res, {
+        docPath: 'homecoming.destination',
+        responseField: 'homecoming_destination',
+        historyPath: 'flight.history',
+        historyLabel: 'homecoming destination',
+        validate: (value) => typeof value === 'string' && HOME_DESTINATION_REGEX.test(value),
+        validationMessage: 'value must be an alphanumeric string up to 30 characters',
+        saveError: 'Failed to update veteran homecoming destination',
+        errorLabel: 'homecoming destination'
+    });
+}
+
+export async function updateVeteranApparelShirtSize(req, res) {
+    return patchVeteranField(req, res, {
+        docPath: 'apparel.shirt_size',
+        responseField: 'apparel_shirt_size',
+        historyPath: 'flight.history',
+        historyLabel: 'apparel shirt size',
+        validate: (value) => typeof value === 'string' && VALID_VETERAN_APPAREL_SHIRT_SIZES.includes(value),
+        validationMessage: 'invalid apparel shirt size',
+        saveError: 'Failed to update veteran apparel shirt size',
+        errorLabel: 'apparel shirt size'
+    });
+}
+
+export async function updateVeteranApparelJacketSize(req, res) {
+    return patchVeteranField(req, res, {
+        docPath: 'apparel.jacket_size',
+        responseField: 'apparel_jacket_size',
+        historyPath: 'flight.history',
+        historyLabel: 'apparel jacket size',
+        validate: (value) => typeof value === 'string' && VALID_VETERAN_APPAREL_JACKET_SIZES.includes(value),
+        validationMessage: 'invalid apparel jacket size',
+        saveError: 'Failed to update veteran apparel jacket size',
+        errorLabel: 'apparel jacket size'
+    });
+}
+
+export async function updateVeteranApparelNotes(req, res) {
+    return patchVeteranField(req, res, {
+        docPath: 'apparel.notes',
+        responseField: 'apparel_notes',
+        historyPath: 'flight.history',
+        historyLabel: 'apparel notes',
+        validate: (value) => typeof value === 'string',
+        validationMessage: 'value must be a string',
+        saveError: 'Failed to update veteran apparel notes',
+        errorLabel: 'apparel notes'
+    });
+}

--- a/schemas/FlightDetailResult.yaml
+++ b/schemas/FlightDetailResult.yaml
@@ -111,9 +111,21 @@ FlightDetailPerson:
     name_last:
       type: string
       description: Last name
+    name_middle:
+      type: string
+      description: Middle name
+    birth_date:
+      type: string
+      description: Birth date
+    gender:
+      type: string
+      description: Gender
     city:
       type: string
       description: City and state
+    phone_mbl:
+      type: string
+      description: Mobile phone number
     bus:
       type: string
       enum: [None, Alpha1, Alpha2, Alpha3, Alpha4, Alpha5, Bravo1, Bravo2, Bravo3, Bravo4, Bravo5]
@@ -137,6 +149,24 @@ FlightDetailPerson:
     confirmed:
       type: boolean
       description: Whether person is confirmed for the flight
+    medical_form:
+      type: boolean
+      description: Whether medical form is received
+    medical_level:
+      type: string
+      description: Medical level
+    flight_vaccinated:
+      type: boolean
+      description: Whether person is marked as vaccinated for flight
+    apparel_shirt_size:
+      type: string
+      description: Apparel shirt size
+    apparel_jacket_size:
+      type: string
+      description: Apparel jacket size
+    apparel_notes:
+      type: string
+      description: Apparel notes
     med_limits:
       type: string
       description: Medical limitations (Veterans only)
@@ -152,3 +182,42 @@ FlightDetailPerson:
     training_complete:
       type: boolean
       description: Whether training is complete (Guardians only)
+    mail_call_received:
+      type: boolean
+      description: Mail call received (Veterans only)
+    mail_call_adopt:
+      type: boolean
+      description: Mail call adopt flag (Veterans only)
+    mail_call_notes:
+      type: string
+      description: Mail call notes (Veterans only)
+    medical_alt_level:
+      type: string
+      description: Alternate medical level (Veterans only)
+    medical_limitations:
+      type: string
+      description: Medical limitations detail (Veterans only)
+    medical_review:
+      type: string
+      description: Medical review notes (Veterans only)
+    medical_requires_oxygen:
+      type: boolean
+      description: Whether oxygen is required (Veterans only)
+    homecoming_destination:
+      type: string
+      description: Homecoming destination (Veterans only)
+    flight_training_notes:
+      type: string
+      description: Training notes (Guardians only)
+    flight_waiver:
+      type: boolean
+      description: Flight waiver flag (Guardians only)
+    flight_training_see_doc:
+      type: boolean
+      description: Training see doctor flag (Guardians only)
+    flight_paid:
+      type: boolean
+      description: Flight paid flag (Guardians only)
+    flight_books_ordered:
+      type: integer
+      description: Number of books ordered (Guardians only)

--- a/test/flight-detail.test.js
+++ b/test/flight-detail.test.js
@@ -94,6 +94,8 @@ describe('Flight Detail Route Handlers', () => {
             await getFlightDetail(req, res);
 
             expect(res.json.called).to.be.true;
+            const secondFetchUrl = global.fetch.secondCall.args[0];
+            expect(secondFetchUrl).to.include('include_docs=true');
             const response = res.json.firstCall.args[0];
             expect(response.flight.name).to.equal('SSHF-Nov2024');
             expect(response.flight.capacity).to.equal(100);
@@ -109,6 +111,158 @@ describe('Flight Detail Route Handlers', () => {
             expect(response.stats.buses.Alpha1).to.equal(2);
             expect(response.stats.tours.Alpha).to.equal(2);
             expect(response.stats.flight.Alpha).to.equal(2);
+        });
+
+        it('should include expanded veteran and guardian fields from row doc', async () => {
+            global.fetch.onFirstCall().resolves({
+                ok: true,
+                json: async () => mockFlightDoc
+            });
+
+            const mockViewResult = {
+                rows: [
+                    {
+                        key: ['SSHF-Nov2024', 'v1', 0],
+                        value: {
+                            type: 'Veteran',
+                            id: 'v1',
+                            name_first: 'John',
+                            name_last: 'Vet',
+                            bus: 'Alpha1',
+                            pairing: 'g1'
+                        },
+                        doc: {
+                            name: { middle: 'M' },
+                            birth_date: '1940-01-02',
+                            gender: 'M',
+                            address: { phone_mbl: '555-101-1000' },
+                            medical: {
+                                form: true,
+                                level: '3',
+                                alt_level: '2',
+                                limitations: 'walker',
+                                review: 'needs review',
+                                requiresOxygen: true
+                            },
+                            mail_call: { received: true, adopt: false, notes: 'mc note' },
+                            flight: { vaccinated: true },
+                            homecoming: { destination: 'Milwaukee' },
+                            apparel: { shirt_size: 'XL', jacket_size: 'L', notes: 'vet apparel' }
+                        }
+                    },
+                    {
+                        key: ['SSHF-Nov2024', 'v1', 1],
+                        value: {
+                            type: 'Guardian',
+                            id: 'g1',
+                            name_first: 'Jane',
+                            name_last: 'Guard',
+                            bus: 'Alpha1',
+                            pairing: 'v1'
+                        },
+                        doc: {
+                            name: { middle: 'Q' },
+                            birth_date: '1960-03-10',
+                            gender: 'F',
+                            address: { phone_mbl: '555-202-2000' },
+                            medical: { form: true, level: 'A' },
+                            flight: {
+                                training_notes: 'note',
+                                waiver: true,
+                                training_see_doc: false,
+                                vaccinated: true,
+                                paid: true,
+                                booksOrdered: 2
+                            },
+                            apparel: { shirt_size: 'WM', jacket_size: 'M', notes: 'guard apparel' }
+                        }
+                    }
+                ]
+            };
+
+            global.fetch.onSecondCall().resolves({
+                ok: true,
+                json: async () => mockViewResult
+            });
+
+            await getFlightDetail(req, res);
+
+            const response = res.json.firstCall.args[0];
+            const veteran = response.pairs[0].people.find(p => p.type === 'Veteran');
+            const guardian = response.pairs[0].people.find(p => p.type === 'Guardian');
+
+            expect(veteran.name_middle).to.equal('M');
+            expect(veteran.birth_date).to.equal('1940-01-02');
+            expect(veteran.gender).to.equal('M');
+            expect(veteran.phone_mbl).to.equal('555-101-1000');
+            expect(veteran.medical_form).to.equal(true);
+            expect(veteran.medical_level).to.equal('3');
+            expect(veteran.mail_call_received).to.equal(true);
+            expect(veteran.mail_call_adopt).to.equal(false);
+            expect(veteran.mail_call_notes).to.equal('mc note');
+            expect(veteran.medical_alt_level).to.equal('2');
+            expect(veteran.medical_limitations).to.equal('walker');
+            expect(veteran.medical_review).to.equal('needs review');
+            expect(veteran.medical_requires_oxygen).to.equal(true);
+            expect(veteran.flight_vaccinated).to.equal(true);
+            expect(veteran.homecoming_destination).to.equal('Milwaukee');
+            expect(veteran.apparel_shirt_size).to.equal('XL');
+            expect(veteran.apparel_jacket_size).to.equal('L');
+            expect(veteran.apparel_notes).to.equal('vet apparel');
+
+            expect(guardian.name_middle).to.equal('Q');
+            expect(guardian.birth_date).to.equal('1960-03-10');
+            expect(guardian.gender).to.equal('F');
+            expect(guardian.phone_mbl).to.equal('555-202-2000');
+            expect(guardian.medical_form).to.equal(true);
+            expect(guardian.medical_level).to.equal('A');
+            expect(guardian.flight_training_notes).to.equal('note');
+            expect(guardian.flight_waiver).to.equal(true);
+            expect(guardian.flight_training_see_doc).to.equal(false);
+            expect(guardian.flight_vaccinated).to.equal(true);
+            expect(guardian.flight_paid).to.equal(true);
+            expect(guardian.flight_books_ordered).to.equal(2);
+            expect(guardian.apparel_shirt_size).to.equal('WM');
+            expect(guardian.apparel_jacket_size).to.equal('M');
+            expect(guardian.apparel_notes).to.equal('guard apparel');
+        });
+
+        it('should not leak veteran-only and guardian-only extended fields across types', async () => {
+            global.fetch.onFirstCall().resolves({
+                ok: true,
+                json: async () => mockFlightDoc
+            });
+
+            const mockViewResult = {
+                rows: [
+                    {
+                        key: ['SSHF-Nov2024', 'v1', 0],
+                        value: { type: 'Veteran', id: 'v1', bus: 'Alpha1', pairing: 'g1' },
+                        doc: { mail_call: { notes: 'vet only' }, flight: { vaccinated: true } }
+                    },
+                    {
+                        key: ['SSHF-Nov2024', 'v1', 1],
+                        value: { type: 'Guardian', id: 'g1', bus: 'Alpha1', pairing: 'v1' },
+                        doc: { flight: { training_notes: 'guardian only', paid: true } }
+                    }
+                ]
+            };
+
+            global.fetch.onSecondCall().resolves({
+                ok: true,
+                json: async () => mockViewResult
+            });
+
+            await getFlightDetail(req, res);
+
+            const response = res.json.firstCall.args[0];
+            const veteran = response.pairs[0].people.find(p => p.type === 'Veteran');
+            const guardian = response.pairs[0].people.find(p => p.type === 'Guardian');
+
+            expect(veteran).to.not.have.property('flight_training_notes');
+            expect(veteran).to.not.have.property('flight_paid');
+            expect(guardian).to.not.have.property('mail_call_notes');
+            expect(guardian).to.not.have.property('homecoming_destination');
         });
 
         it('should return empty pairs for flight with no assignments', async () => {

--- a/test/flight_detail.test.js
+++ b/test/flight_detail.test.js
@@ -181,8 +181,13 @@ describe('Flight Detail Models', () => {
                 });
                 const json = person.toJSON();
                 expect(json).to.have.all.keys([
-                    'type', 'id', 'name_first', 'name_last', 'city', 'bus', 'seat',
-                    'shirt', 'fm_number', 'assigned_to', 'nofly', 'confirmed', 'med_limits', 'group'
+                    'type', 'id', 'name_first', 'name_last', 'name_middle', 'birth_date', 'gender',
+                    'city', 'phone_mbl', 'bus', 'seat', 'shirt', 'fm_number', 'assigned_to',
+                    'nofly', 'confirmed', 'medical_form', 'medical_level', 'flight_vaccinated',
+                    'apparel_shirt_size', 'apparel_jacket_size', 'apparel_notes',
+                    'med_limits', 'group', 'mail_call_received', 'mail_call_adopt',
+                    'mail_call_notes', 'medical_alt_level', 'medical_limitations',
+                    'medical_review', 'medical_requires_oxygen', 'homecoming_destination'
                 ]);
                 expect(json.type).to.equal('Veteran');
                 expect(json.fm_number).to.equal('FM38');
@@ -204,8 +209,12 @@ describe('Flight Detail Models', () => {
                 });
                 const json = person.toJSON();
                 expect(json).to.have.all.keys([
-                    'type', 'id', 'name_first', 'name_last', 'city', 'bus', 'seat',
-                    'shirt', 'fm_number', 'assigned_to', 'nofly', 'confirmed', 'med_exprnc', 'training', 'training_complete'
+                    'type', 'id', 'name_first', 'name_last', 'name_middle', 'birth_date', 'gender',
+                    'city', 'phone_mbl', 'bus', 'seat', 'shirt', 'fm_number', 'assigned_to',
+                    'nofly', 'confirmed', 'medical_form', 'medical_level', 'flight_vaccinated',
+                    'apparel_shirt_size', 'apparel_jacket_size', 'apparel_notes',
+                    'med_exprnc', 'training', 'training_complete', 'flight_training_notes',
+                    'flight_waiver', 'flight_training_see_doc', 'flight_paid', 'flight_books_ordered'
                 ]);
                 expect(json.type).to.equal('Guardian');
                 expect(json.fm_number).to.equal('');
@@ -242,6 +251,114 @@ describe('Flight Detail Models', () => {
                 expect(person.confirmed).to.equal(true);
             });
 
+            it('should extract veteran extended fields from row.doc', () => {
+                const row = {
+                    type: 'Veteran',
+                    id: 'vet-doc-1',
+                    name_first: 'Tom',
+                    name_last: 'Brown',
+                    bus: 'Alpha1',
+                    doc: {
+                        name: { middle: 'Q' },
+                        birth_date: '1945-01-01',
+                        gender: 'M',
+                        address: { phone_mbl: '555-123-9999' },
+                        medical: {
+                            form: true,
+                            level: '3',
+                            alt_level: '2',
+                            limitations: 'uses cane',
+                            review: 'review note',
+                            requiresOxygen: true
+                        },
+                        mail_call: {
+                            received: true,
+                            adopt: false,
+                            notes: 'mail note'
+                        },
+                        flight: { vaccinated: true },
+                        homecoming: { destination: 'Madison' },
+                        apparel: {
+                            shirt_size: 'XL',
+                            jacket_size: 'L',
+                            notes: 'apparel note'
+                        }
+                    }
+                };
+
+                const person = FlightDetailPerson.fromViewRow(row);
+                const json = person.toJSON();
+                expect(json.name_middle).to.equal('Q');
+                expect(json.birth_date).to.equal('1945-01-01');
+                expect(json.gender).to.equal('M');
+                expect(json.phone_mbl).to.equal('555-123-9999');
+                expect(json.medical_form).to.equal(true);
+                expect(json.medical_level).to.equal('3');
+                expect(json.medical_alt_level).to.equal('2');
+                expect(json.medical_limitations).to.equal('uses cane');
+                expect(json.medical_review).to.equal('review note');
+                expect(json.medical_requires_oxygen).to.equal(true);
+                expect(json.mail_call_received).to.equal(true);
+                expect(json.mail_call_adopt).to.equal(false);
+                expect(json.mail_call_notes).to.equal('mail note');
+                expect(json.flight_vaccinated).to.equal(true);
+                expect(json.homecoming_destination).to.equal('Madison');
+                expect(json.apparel_shirt_size).to.equal('XL');
+                expect(json.apparel_jacket_size).to.equal('L');
+                expect(json.apparel_notes).to.equal('apparel note');
+            });
+
+            it('should extract guardian extended fields from row.doc', () => {
+                const row = {
+                    type: 'Guardian',
+                    id: 'guard-doc-1',
+                    name_first: 'Pat',
+                    name_last: 'Jones',
+                    bus: 'Bravo1',
+                    doc: {
+                        name: { middle: 'R' },
+                        birth_date: '1960-03-12',
+                        gender: 'F',
+                        address: { phone_mbl: '555-000-1111' },
+                        medical: {
+                            form: false,
+                            level: 'A'
+                        },
+                        flight: {
+                            training_notes: 'needs follow-up',
+                            waiver: true,
+                            training_see_doc: false,
+                            vaccinated: true,
+                            paid: true,
+                            booksOrdered: 3
+                        },
+                        apparel: {
+                            shirt_size: 'WM',
+                            jacket_size: 'M',
+                            notes: 'guardian apparel note'
+                        }
+                    }
+                };
+
+                const person = FlightDetailPerson.fromViewRow(row);
+                const json = person.toJSON();
+                expect(json.name_middle).to.equal('R');
+                expect(json.birth_date).to.equal('1960-03-12');
+                expect(json.gender).to.equal('F');
+                expect(json.phone_mbl).to.equal('555-000-1111');
+                expect(json.medical_form).to.equal(false);
+                expect(json.medical_level).to.equal('A');
+                expect(json.flight_training_notes).to.equal('needs follow-up');
+                expect(json.flight_waiver).to.equal(true);
+                expect(json.flight_training_see_doc).to.equal(false);
+                expect(json.flight_vaccinated).to.equal(true);
+                expect(json.flight_paid).to.equal(true);
+                expect(json.flight_books_ordered).to.equal(3);
+                expect(json.apparel_shirt_size).to.equal('WM');
+                expect(json.apparel_jacket_size).to.equal('M');
+                expect(json.apparel_notes).to.equal('guardian apparel note');
+            });
+
             it('should handle missing properties with defaults', () => {
                 const row = {};
                 const person = FlightDetailPerson.fromViewRow(row);
@@ -252,6 +369,31 @@ describe('Flight Detail Models', () => {
                 expect(person.nofly).to.equal(false);
             });
 
+            it('should default extended fields when row.doc is missing nested data', () => {
+                const row = {
+                    type: 'Guardian',
+                    id: 'g-empty-doc',
+                    doc: {}
+                };
+                const person = FlightDetailPerson.fromViewRow(row);
+                const json = person.toJSON();
+                expect(json.name_middle).to.equal('');
+                expect(json.birth_date).to.equal('');
+                expect(json.gender).to.equal('');
+                expect(json.phone_mbl).to.equal('');
+                expect(json.medical_form).to.equal(false);
+                expect(json.medical_level).to.equal('');
+                expect(json.flight_training_notes).to.equal('');
+                expect(json.flight_waiver).to.equal(false);
+                expect(json.flight_training_see_doc).to.equal(false);
+                expect(json.flight_vaccinated).to.equal(false);
+                expect(json.flight_paid).to.equal(false);
+                expect(json.flight_books_ordered).to.equal(0);
+                expect(json.apparel_shirt_size).to.equal('');
+                expect(json.apparel_jacket_size).to.equal('');
+                expect(json.apparel_notes).to.equal('');
+            });
+
             it('should parse confirmed string "confirmed" from view row', () => {
                 const row = {
                     type: 'Veteran',
@@ -260,6 +402,14 @@ describe('Flight Detail Models', () => {
                 };
                 const person = FlightDetailPerson.fromViewRow(row);
                 expect(person.confirmed).to.equal(true);
+            });
+
+            it('should handle undefined row input safely', () => {
+                const person = FlightDetailPerson.fromViewRow(undefined);
+                expect(person).to.be.instanceOf(FlightDetailPerson);
+                expect(person.type).to.equal('');
+                expect(person.id).to.equal('');
+                expect(person.bus).to.equal('None');
             });
         });
     });

--- a/test/guardians.test.js
+++ b/test/guardians.test.js
@@ -1,6 +1,24 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { createGuardian, retrieveGuardian, updateGuardian, deleteGuardian, updateGuardianSeat, updateGuardianBus } from '../routes/guardians.js';
+import {
+    createGuardian,
+    retrieveGuardian,
+    updateGuardian,
+    deleteGuardian,
+    updateGuardianSeat,
+    updateGuardianBus,
+    updateGuardianTrainingNotes,
+    updateGuardianTrainingComplete,
+    updateGuardianWaiver,
+    updateGuardianTrainingSeeDoc,
+    updateGuardianVaccinated,
+    updateGuardianMedicalForm,
+    updateGuardianPaid,
+    updateGuardianBooksOrdered,
+    updateGuardianApparelShirtSize,
+    updateGuardianApparelJacketSize,
+    updateGuardianApparelNotes
+} from '../routes/guardians.js';
 import { DatabaseSessionError } from '../utils/db.js';
 
 describe('Guardians Route Handlers', () => {
@@ -1748,6 +1766,287 @@ describe('Guardians Route Handlers', () => {
             await updateGuardianBus(req, res);
 
             expect(res.status.calledWith(503)).to.be.true;
+        });
+    });
+
+    describe('extended guardian patch handlers', () => {
+        const baseDoc = {
+            _id: 'guard-extended-1',
+            _rev: '1-abc',
+            type: 'Guardian',
+            flight: {
+                training_notes: 'old training notes',
+                training_complete: false,
+                waiver: false,
+                training_see_doc: false,
+                vaccinated: false,
+                paid: false,
+                booksOrdered: 0,
+                history: []
+            },
+            medical: { form: false },
+            apparel: { shirt_size: 'M', jacket_size: 'L', notes: 'old notes' },
+            call: { history: [] },
+            metadata: {}
+        };
+
+        const cases = [
+            {
+                name: 'training-notes',
+                handler: updateGuardianTrainingNotes,
+                valid: 'updated training notes',
+                invalid: 42,
+                expectedField: 'training_notes',
+                docGetter: (doc) => doc.flight.training_notes
+            },
+            {
+                name: 'training-complete',
+                handler: updateGuardianTrainingComplete,
+                valid: true,
+                invalid: 'bad',
+                expectedField: 'training_complete',
+                docGetter: (doc) => doc.flight.training_complete
+            },
+            {
+                name: 'waiver',
+                handler: updateGuardianWaiver,
+                valid: true,
+                invalid: 'bad',
+                expectedField: 'waiver',
+                docGetter: (doc) => doc.flight.waiver
+            },
+            {
+                name: 'training-see-doc',
+                handler: updateGuardianTrainingSeeDoc,
+                valid: true,
+                invalid: 'bad',
+                expectedField: 'training_see_doc',
+                docGetter: (doc) => doc.flight.training_see_doc
+            },
+            {
+                name: 'vaccinated',
+                handler: updateGuardianVaccinated,
+                valid: true,
+                invalid: 'bad',
+                expectedField: 'vaccinated',
+                docGetter: (doc) => doc.flight.vaccinated
+            },
+            {
+                name: 'medical-form',
+                handler: updateGuardianMedicalForm,
+                valid: true,
+                invalid: 'bad',
+                expectedField: 'medical_form',
+                docGetter: (doc) => doc.medical.form
+            },
+            {
+                name: 'paid',
+                handler: updateGuardianPaid,
+                valid: true,
+                invalid: 'bad',
+                expectedField: 'paid',
+                docGetter: (doc) => doc.flight.paid
+            },
+            {
+                name: 'books-ordered',
+                handler: updateGuardianBooksOrdered,
+                valid: 3,
+                invalid: 10,
+                expectedField: 'books_ordered',
+                docGetter: (doc) => doc.flight.booksOrdered
+            },
+            {
+                name: 'apparel-shirt-size',
+                handler: updateGuardianApparelShirtSize,
+                valid: 'WM',
+                invalid: 'BAD',
+                expectedField: 'apparel_shirt_size',
+                docGetter: (doc) => doc.apparel.shirt_size
+            },
+            {
+                name: 'apparel-jacket-size',
+                handler: updateGuardianApparelJacketSize,
+                valid: 'XL',
+                invalid: 'BAD',
+                expectedField: 'apparel_jacket_size',
+                docGetter: (doc) => doc.apparel.jacket_size
+            },
+            {
+                name: 'apparel-notes',
+                handler: updateGuardianApparelNotes,
+                valid: 'new apparel note',
+                invalid: 42,
+                expectedField: 'apparel_notes',
+                docGetter: (doc) => doc.apparel.notes
+            }
+        ];
+
+        for (const testCase of cases) {
+            it(`should update ${testCase.name} successfully`, async () => {
+                req.body = { value: testCase.valid };
+                global.fetch.onFirstCall().resolves({
+                    ok: true,
+                    json: async () => JSON.parse(JSON.stringify(baseDoc))
+                });
+                let savedDoc = null;
+                global.fetch.onSecondCall().callsFake(async (url, options) => {
+                    savedDoc = JSON.parse(options.body);
+                    return { ok: true, json: async () => ({ id: baseDoc._id, rev: '2-new' }) };
+                });
+
+                await testCase.handler(req, res);
+
+                expect(res.json.called).to.be.true;
+                const response = res.json.firstCall.args[0];
+                expect(response.ok).to.equal(true);
+                expect(response[testCase.expectedField]).to.deep.equal(testCase.valid);
+                expect(testCase.docGetter(savedDoc)).to.deep.equal(testCase.valid);
+                expect(savedDoc.metadata.updated_at).to.be.a('string');
+                expect(savedDoc.metadata.updated_by).to.equal('Admin User');
+                expect(savedDoc.flight.history.length).to.equal(1);
+                expect(savedDoc.flight.history[0].change).to.include('changed');
+            });
+
+            it(`should return 400 for invalid value on ${testCase.name}`, async () => {
+                req.body = { value: testCase.invalid };
+                await testCase.handler(req, res);
+                expect(res.status.calledWith(400)).to.be.true;
+            });
+
+            it(`should return 400 when value missing on ${testCase.name}`, async () => {
+                req.body = {};
+                await testCase.handler(req, res);
+                expect(res.status.calledWith(400)).to.be.true;
+                expect(res.json.firstCall.args[0].error).to.include('value is required');
+            });
+
+            it(`should return 404 when guardian missing on ${testCase.name}`, async () => {
+                req.body = { value: testCase.valid };
+                global.fetch.onFirstCall().resolves({
+                    ok: false,
+                    status: 404,
+                    json: async () => ({ error: 'not_found' })
+                });
+                await testCase.handler(req, res);
+                expect(res.status.calledWith(404)).to.be.true;
+            });
+
+            it(`should return 400 for wrong document type on ${testCase.name}`, async () => {
+                req.body = { value: testCase.valid };
+                global.fetch.onFirstCall().resolves({
+                    ok: true,
+                    json: async () => ({ _id: 'doc-x', type: 'Veteran' })
+                });
+                await testCase.handler(req, res);
+                expect(res.status.calledWith(400)).to.be.true;
+            });
+
+            it(`should return 500 when save fails on ${testCase.name}`, async () => {
+                req.body = { value: testCase.valid };
+                global.fetch.onFirstCall().resolves({
+                    ok: true,
+                    json: async () => JSON.parse(JSON.stringify(baseDoc))
+                });
+                global.fetch.onSecondCall().resolves({
+                    ok: false,
+                    json: async () => ({ reason: 'Conflict' })
+                });
+                await testCase.handler(req, res);
+                expect(res.status.calledWith(500)).to.be.true;
+            });
+
+            it(`should return 503 when session fails on ${testCase.name}`, async () => {
+                req.body = { value: testCase.valid };
+                global.fetch.resolves({
+                    ok: false,
+                    status: 401
+                });
+                await testCase.handler(req, res);
+                expect(res.status.calledWith(503)).to.be.true;
+            });
+        }
+
+        it('should return 500 for non-404 fetch failure in helper', async () => {
+            req.body = { value: true };
+            global.fetch.onFirstCall().resolves({
+                ok: false,
+                status: 500,
+                json: async () => ({ error: 'db_error' })
+            });
+
+            await updateGuardianWaiver(req, res);
+
+            expect(res.status.calledWith(500)).to.be.true;
+            expect(res.json.firstCall.args[0].error).to.include('Failed to get guardian for update');
+        });
+
+        it('should initialize missing flight history and metadata object', async () => {
+            req.body = { value: true };
+            const docWithoutHistoryOrMetadata = {
+                _id: 'guard-init-1',
+                _rev: '1-a',
+                type: 'Guardian',
+                flight: {},
+                medical: {},
+                apparel: {}
+            };
+            global.fetch.onFirstCall().resolves({
+                ok: true,
+                json: async () => JSON.parse(JSON.stringify(docWithoutHistoryOrMetadata))
+            });
+            let savedDoc = null;
+            global.fetch.onSecondCall().callsFake(async (url, options) => {
+                savedDoc = JSON.parse(options.body);
+                return { ok: true, json: async () => ({ id: 'guard-init-1', rev: '2-b' }) };
+            });
+
+            await updateGuardianTrainingComplete(req, res);
+
+            expect(savedDoc.flight.history).to.be.an('array');
+            expect(savedDoc.flight.history.length).to.equal(1);
+            expect(savedDoc.metadata).to.be.an('object');
+            expect(savedDoc.metadata.updated_by).to.equal('Admin User');
+        });
+
+        it('should create missing nested objects when setting values', async () => {
+            req.body = { value: true };
+            const docWithoutNestedParents = {
+                _id: 'guard-nested-1',
+                _rev: '1-a',
+                type: 'Guardian'
+            };
+            global.fetch.onFirstCall().resolves({
+                ok: true,
+                json: async () => JSON.parse(JSON.stringify(docWithoutNestedParents))
+            });
+            let savedDoc = null;
+            global.fetch.onSecondCall().callsFake(async (url, options) => {
+                savedDoc = JSON.parse(options.body);
+                return { ok: true, json: async () => ({ id: 'guard-nested-1', rev: '2-b' }) };
+            });
+
+            await updateGuardianPaid(req, res);
+
+            expect(savedDoc.flight).to.be.an('object');
+            expect(savedDoc.flight.paid).to.equal(true);
+            expect(savedDoc.flight.history).to.be.an('array');
+        });
+
+        it('should use configured save error message when save fails without reason', async () => {
+            req.body = { value: true };
+            global.fetch.onFirstCall().resolves({
+                ok: true,
+                json: async () => JSON.parse(JSON.stringify(baseDoc))
+            });
+            global.fetch.onSecondCall().resolves({
+                ok: false,
+                json: async () => ({})
+            });
+
+            await updateGuardianWaiver(req, res);
+
+            expect(res.status.calledWith(500)).to.be.true;
+            expect(res.json.firstCall.args[0].error).to.equal('Failed to update guardian waiver');
         });
     });
 }); 

--- a/test/veterans.test.js
+++ b/test/veterans.test.js
@@ -1,6 +1,22 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { createVeteran, retrieveVeteran, updateVeteran, deleteVeteran, updateVeteranSeat, updateVeteranBus } from '../routes/veterans.js';
+import {
+    createVeteran,
+    retrieveVeteran,
+    updateVeteran,
+    deleteVeteran,
+    updateVeteranSeat,
+    updateVeteranBus,
+    updateVeteranMailCallReceived,
+    updateVeteranMailCallAdopt,
+    updateVeteranMedicalForm,
+    updateVeteranMedicalReview,
+    updateVeteranVaccinated,
+    updateVeteranHomecomingDestination,
+    updateVeteranApparelShirtSize,
+    updateVeteranApparelJacketSize,
+    updateVeteranApparelNotes
+} from '../routes/veterans.js';
 import { DatabaseSessionError } from '../utils/db.js';
 
 describe('Veterans Route Handlers', () => {
@@ -937,6 +953,279 @@ describe('Veterans Route Handlers', () => {
             await updateVeteranBus(req, res);
 
             expect(res.status.calledWith(503)).to.be.true;
+        });
+    });
+
+    describe('extended veteran patch handlers', () => {
+        const baseDoc = {
+            _id: 'vet-extended-1',
+            _rev: '1-abc',
+            type: 'Veteran',
+            mail_call: { received: false, adopt: false, notes: 'old note' },
+            medical: { form: false, review: 'old review' },
+            flight: { vaccinated: false, history: [] },
+            homecoming: { destination: 'OldTown' },
+            apparel: { shirt_size: 'M', jacket_size: 'L', notes: 'old apparel' },
+            call: { history: [] },
+            metadata: {}
+        };
+
+        const cases = [
+            {
+                name: 'mail-call-received',
+                handler: updateVeteranMailCallReceived,
+                valid: true,
+                invalid: 'bad',
+                expectedField: 'mail_call_received',
+                docGetter: (doc) => doc.mail_call.received,
+                historyPath: 'call.history'
+            },
+            {
+                name: 'mail-call-adopt',
+                handler: updateVeteranMailCallAdopt,
+                valid: true,
+                invalid: 'bad',
+                expectedField: 'mail_call_adopt',
+                docGetter: (doc) => doc.mail_call.adopt,
+                historyPath: 'call.history'
+            },
+            {
+                name: 'medical-form',
+                handler: updateVeteranMedicalForm,
+                valid: true,
+                invalid: 'bad',
+                expectedField: 'medical_form',
+                docGetter: (doc) => doc.medical.form,
+                historyPath: 'flight.history'
+            },
+            {
+                name: 'medical-review',
+                handler: updateVeteranMedicalReview,
+                valid: 'new medical review',
+                invalid: 42,
+                expectedField: 'medical_review',
+                docGetter: (doc) => doc.medical.review,
+                historyPath: 'flight.history'
+            },
+            {
+                name: 'vaccinated',
+                handler: updateVeteranVaccinated,
+                valid: true,
+                invalid: 'bad',
+                expectedField: 'flight_vaccinated',
+                docGetter: (doc) => doc.flight.vaccinated,
+                historyPath: 'flight.history'
+            },
+            {
+                name: 'homecoming-destination',
+                handler: updateVeteranHomecomingDestination,
+                valid: 'Madison',
+                invalid: 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+                expectedField: 'homecoming_destination',
+                docGetter: (doc) => doc.homecoming.destination,
+                historyPath: 'flight.history'
+            },
+            {
+                name: 'apparel-shirt-size',
+                handler: updateVeteranApparelShirtSize,
+                valid: 'XL',
+                invalid: 'BAD',
+                expectedField: 'apparel_shirt_size',
+                docGetter: (doc) => doc.apparel.shirt_size,
+                historyPath: 'flight.history'
+            },
+            {
+                name: 'apparel-jacket-size',
+                handler: updateVeteranApparelJacketSize,
+                valid: 'XL',
+                invalid: 'BAD',
+                expectedField: 'apparel_jacket_size',
+                docGetter: (doc) => doc.apparel.jacket_size,
+                historyPath: 'flight.history'
+            },
+            {
+                name: 'apparel-notes',
+                handler: updateVeteranApparelNotes,
+                valid: 'new apparel note',
+                invalid: 42,
+                expectedField: 'apparel_notes',
+                docGetter: (doc) => doc.apparel.notes,
+                historyPath: 'flight.history'
+            }
+        ];
+
+        function getPathValue(obj, path) {
+            return path.split('.').reduce((acc, key) => acc[key], obj);
+        }
+
+        for (const testCase of cases) {
+            it(`should update ${testCase.name} successfully`, async () => {
+                req.body = { value: testCase.valid };
+                global.fetch.onFirstCall().resolves({
+                    ok: true,
+                    json: async () => JSON.parse(JSON.stringify(baseDoc))
+                });
+                let savedDoc = null;
+                global.fetch.onSecondCall().callsFake(async (url, options) => {
+                    savedDoc = JSON.parse(options.body);
+                    return { ok: true, json: async () => ({ id: baseDoc._id, rev: '2-new' }) };
+                });
+
+                await testCase.handler(req, res);
+
+                expect(res.json.called).to.be.true;
+                const response = res.json.firstCall.args[0];
+                expect(response.ok).to.equal(true);
+                expect(response[testCase.expectedField]).to.deep.equal(testCase.valid);
+                expect(testCase.docGetter(savedDoc)).to.deep.equal(testCase.valid);
+                expect(savedDoc.metadata.updated_at).to.be.a('string');
+                expect(savedDoc.metadata.updated_by).to.equal('Admin User');
+                const history = getPathValue(savedDoc, testCase.historyPath);
+                expect(history.length).to.equal(1);
+                expect(history[0].change).to.include('changed');
+            });
+
+            it(`should return 400 for invalid value on ${testCase.name}`, async () => {
+                req.body = { value: testCase.invalid };
+                await testCase.handler(req, res);
+                expect(res.status.calledWith(400)).to.be.true;
+            });
+
+            it(`should return 400 when value missing on ${testCase.name}`, async () => {
+                req.body = {};
+                await testCase.handler(req, res);
+                expect(res.status.calledWith(400)).to.be.true;
+                expect(res.json.firstCall.args[0].error).to.include('value is required');
+            });
+
+            it(`should return 404 when veteran missing on ${testCase.name}`, async () => {
+                req.body = { value: testCase.valid };
+                global.fetch.onFirstCall().resolves({
+                    ok: false,
+                    status: 404,
+                    json: async () => ({ error: 'not_found' })
+                });
+                await testCase.handler(req, res);
+                expect(res.status.calledWith(404)).to.be.true;
+            });
+
+            it(`should return 400 for wrong document type on ${testCase.name}`, async () => {
+                req.body = { value: testCase.valid };
+                global.fetch.onFirstCall().resolves({
+                    ok: true,
+                    json: async () => ({ _id: 'doc-x', type: 'Guardian' })
+                });
+                await testCase.handler(req, res);
+                expect(res.status.calledWith(400)).to.be.true;
+            });
+
+            it(`should return 500 when save fails on ${testCase.name}`, async () => {
+                req.body = { value: testCase.valid };
+                global.fetch.onFirstCall().resolves({
+                    ok: true,
+                    json: async () => JSON.parse(JSON.stringify(baseDoc))
+                });
+                global.fetch.onSecondCall().resolves({
+                    ok: false,
+                    json: async () => ({ reason: 'Conflict' })
+                });
+                await testCase.handler(req, res);
+                expect(res.status.calledWith(500)).to.be.true;
+            });
+
+            it(`should return 503 when session fails on ${testCase.name}`, async () => {
+                req.body = { value: testCase.valid };
+                global.fetch.resolves({
+                    ok: false,
+                    status: 401
+                });
+                await testCase.handler(req, res);
+                expect(res.status.calledWith(503)).to.be.true;
+            });
+        }
+
+        it('should return 500 for non-404 fetch failure in helper', async () => {
+            req.body = { value: true };
+            global.fetch.onFirstCall().resolves({
+                ok: false,
+                status: 500,
+                json: async () => ({ error: 'db_error' })
+            });
+
+            await updateVeteranMedicalForm(req, res);
+
+            expect(res.status.calledWith(500)).to.be.true;
+            expect(res.json.firstCall.args[0].error).to.include('Failed to get veteran for update');
+        });
+
+        it('should initialize missing history array and metadata object', async () => {
+            req.body = { value: true };
+            const docWithoutHistoryOrMetadata = {
+                _id: 'vet-init-1',
+                _rev: '1-a',
+                type: 'Veteran',
+                mail_call: {},
+                call: {},
+                flight: {}
+            };
+            global.fetch.onFirstCall().resolves({
+                ok: true,
+                json: async () => JSON.parse(JSON.stringify(docWithoutHistoryOrMetadata))
+            });
+            let savedDoc = null;
+            global.fetch.onSecondCall().callsFake(async (url, options) => {
+                savedDoc = JSON.parse(options.body);
+                return { ok: true, json: async () => ({ id: 'vet-init-1', rev: '2-b' }) };
+            });
+
+            await updateVeteranMailCallReceived(req, res);
+
+            expect(savedDoc.call.history).to.be.an('array');
+            expect(savedDoc.call.history.length).to.equal(1);
+            expect(savedDoc.metadata).to.be.an('object');
+            expect(savedDoc.metadata.updated_by).to.equal('Admin User');
+        });
+
+        it('should create missing nested objects when setting values', async () => {
+            req.body = { value: true };
+            const docWithoutNestedParents = {
+                _id: 'vet-nested-1',
+                _rev: '1-a',
+                type: 'Veteran'
+            };
+            global.fetch.onFirstCall().resolves({
+                ok: true,
+                json: async () => JSON.parse(JSON.stringify(docWithoutNestedParents))
+            });
+            let savedDoc = null;
+            global.fetch.onSecondCall().callsFake(async (url, options) => {
+                savedDoc = JSON.parse(options.body);
+                return { ok: true, json: async () => ({ id: 'vet-nested-1', rev: '2-b' }) };
+            });
+
+            await updateVeteranMedicalForm(req, res);
+
+            expect(savedDoc.medical).to.be.an('object');
+            expect(savedDoc.medical.form).to.equal(true);
+            expect(savedDoc.flight).to.be.an('object');
+            expect(savedDoc.flight.history).to.be.an('array');
+        });
+
+        it('should use configured save error message when save fails without reason', async () => {
+            req.body = { value: true };
+            global.fetch.onFirstCall().resolves({
+                ok: true,
+                json: async () => JSON.parse(JSON.stringify(baseDoc))
+            });
+            global.fetch.onSecondCall().resolves({
+                ok: false,
+                json: async () => ({})
+            });
+
+            await updateVeteranMedicalForm(req, res);
+
+            expect(res.status.calledWith(500)).to.be.true;
+            expect(res.json.firstCall.args[0].error).to.equal('Failed to update veteran medical form');
         });
     });
 }); 


### PR DESCRIPTION
- Refactored cursor rules for project to make them more modular and give more consistent results.
- Expanded `flight detail` model payload in `models/flight_detail.js`:
  - Added all requested common fields:
    - `name_middle`, `birth_date`, `gender`, `phone_mbl`
    - `medical_form`, `medical_level`
    - `flight_vaccinated`
    - `apparel_shirt_size`, `apparel_jacket_size`, `apparel_notes`
  - Added veteran-only fields:
    - `mail_call_received`, `mail_call_adopt`, `mail_call_notes`
    - `medical_alt_level`, `medical_limitations`, `medical_review`, `medical_requires_oxygen`
    - `homecoming_destination`
  - Added guardian-only fields:
    - `flight_training_notes`, `flight_waiver`, `flight_training_see_doc`
    - `flight_paid`, `flight_books_ordered`
  - Updated `fromViewRow` to read from full view row (`row.value` + `row.doc`) with safe defaults.
  - Updated pairing builder to pass full row into `fromViewRow`.

- Updated `routes/flight-detail.js`:
  - Added `include_docs=true` to `basic/flight_pairings` query.
  - Kept existing behavior/stats/pairing logic intact, now enriched by doc-backed fields.

- Added 9 veteran per-field PATCH handlers in `routes/veterans.js`:
  - `/veterans/:id/mail-call-received`
  - `/veterans/:id/mail-call-adopt`
  - `/veterans/:id/medical-form`
  - `/veterans/:id/medical-review`
  - `/veterans/:id/vaccinated`
  - `/veterans/:id/homecoming-destination`
  - `/veterans/:id/apparel-shirt-size`
  - `/veterans/:id/apparel-jacket-size`
  - `/veterans/:id/apparel-notes`
  - Implemented with validation, type checks, history updates (`call.history` for mail-call fields, `flight.history` for others), metadata updates, and consistent error handling.

- Added 11 guardian per-field PATCH handlers in `routes/guardians.js`:
  - `/guardians/:id/training-notes`
  - `/guardians/:id/training-complete`
  - `/guardians/:id/waiver`
  - `/guardians/:id/training-see-doc`
  - `/guardians/:id/vaccinated`
  - `/guardians/:id/medical-form`
  - `/guardians/:id/paid`
  - `/guardians/:id/books-ordered`
  - `/guardians/:id/apparel-shirt-size`
  - `/guardians/:id/apparel-jacket-size`
  - `/guardians/:id/apparel-notes`
  - Same validation/history/metadata/error handling pattern as veteran endpoints.

- Wired all new routes in `index.js`.

- Updated schema docs in `schemas/FlightDetailResult.yaml` with all new `FlightDetailPerson` fields.

- Updated endpoint list in `README.md` with the new flight-detail-related PATCH endpoints.

---

### Tests added/updated first, then implementation

- `test/flight_detail.test.js`
  - Added model tests for row-doc extraction and defaults for new fields.
- `test/flight-detail.test.js`
  - Added assertions for `include_docs=true` and expanded response fields.
  - Added cross-type non-leak assertions.
- `test/veterans.test.js`
  - Added table-driven coverage for all 9 new veteran handlers:
    - success, invalid value, missing value, 404, wrong doc type, save failure, 503 session failure.
- `test/guardians.test.js`
  - Added table-driven coverage for all 11 new guardian handlers with same coverage matrix.
- Adjusted existing keyset expectations in `test/flight_detail.test.js` to include expanded model fields.

