### PR TITLE
Trim whitespace on text fields before CouchDB writes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ coverage/
 # misc
 .DS_Store
 .env
+*.swp
+*~

--- a/models/flight.js
+++ b/models/flight.js
@@ -1,5 +1,8 @@
+import { trimStringValues } from '../utils/trim_strings.js';
+
 export class Flight {
     constructor(data = {}) {
+        data = trimStringValues(data);
         this._id = data._id || '';
         this._rev = data._rev || '';
         this.type = data.type || 'Flight';

--- a/models/guardian.js
+++ b/models/guardian.js
@@ -1,5 +1,8 @@
+import { trimStringValues } from '../utils/trim_strings.js';
+
 export class Guardian {
     constructor(data = {}) {
+        data = trimStringValues(data);
         this._id = data._id || '';
         this._rev = data._rev || '';
         this.type = data.type || 'Guardian';

--- a/models/veteran.js
+++ b/models/veteran.js
@@ -1,5 +1,8 @@
+import { trimStringValues } from '../utils/trim_strings.js';
+
 export class Veteran {
     constructor(data = {}) {
+        data = trimStringValues(data);
         this._id = data._id || '';
         this._rev = data._rev || '';
         this.type = data.type || '';

--- a/routes/guardians.js
+++ b/routes/guardians.js
@@ -2,6 +2,7 @@ import { Guardian } from '../models/guardian.js';
 import { Veteran } from '../models/veteran.js';
 import { VALID_BUSES } from '../models/flight_detail.js';
 import { dbFetch, DatabaseSessionError } from '../utils/db.js';
+import { trimIfString } from '../utils/trim_strings.js';
 
 const dbUrl = process.env.DB_URL;
 const dbName = process.env.DB_NAME;
@@ -602,7 +603,7 @@ export async function updateGuardianSeat(req, res) {
             return res.status(400).json({ error: 'value is required' });
         }
 
-        const newSeat = String(value);
+        const newSeat = trimIfString(String(value));
 
         // Get the current document
         const url = `${dbUrl}/${dbName}/${docId}`;
@@ -747,7 +748,7 @@ export async function updateGuardianBus(req, res) {
             return res.status(400).json({ error: 'value is required' });
         }
 
-        const newBus = String(value);
+        const newBus = trimIfString(String(value));
 
         // Validate bus value
         if (!VALID_BUSES.includes(newBus)) {
@@ -866,10 +867,11 @@ function setNestedValue(obj, path, value) {
 async function patchGuardianField(req, res, config) {
     try {
         const docId = req.params.id;
-        const { value } = req.body;
+        let { value } = req.body;
         if (value === undefined || value === null) {
             return res.status(400).json({ error: 'value is required' });
         }
+        value = trimIfString(value);
         if (config.validate && !config.validate(value)) {
             return res.status(400).json({ error: config.validationMessage });
         }

--- a/routes/veterans.js
+++ b/routes/veterans.js
@@ -3,6 +3,7 @@ import { UnpairedVeteranRequest } from '../models/unpaired_veteran_request.js';
 import { UnpairedVeteranResults } from '../models/unpaired_veteran_results.js';
 import { VALID_BUSES } from '../models/flight_detail.js';
 import { dbFetch, DatabaseSessionError } from '../utils/db.js';
+import { trimIfString } from '../utils/trim_strings.js';
 
 const dbUrl = process.env.DB_URL;
 const dbName = process.env.DB_NAME;
@@ -528,7 +529,7 @@ export async function updateVeteranSeat(req, res) {
             return res.status(400).json({ error: 'value is required' });
         }
 
-        const newSeat = String(value);
+        const newSeat = trimIfString(String(value));
 
         // Get the current document
         const url = `${dbUrl}/${dbName}/${docId}`;
@@ -673,7 +674,7 @@ export async function updateVeteranBus(req, res) {
             return res.status(400).json({ error: 'value is required' });
         }
 
-        const newBus = String(value);
+        const newBus = trimIfString(String(value));
 
         // Validate bus value
         if (!VALID_BUSES.includes(newBus)) {
@@ -793,10 +794,11 @@ function setNestedValue(obj, path, value) {
 async function patchVeteranField(req, res, config) {
     try {
         const docId = req.params.id;
-        const { value } = req.body;
+        let { value } = req.body;
         if (value === undefined || value === null) {
             return res.status(400).json({ error: 'value is required' });
         }
+        value = trimIfString(value);
         if (config.validate && !config.validate(value)) {
             return res.status(400).json({ error: config.validationMessage });
         }

--- a/test/flight.test.js
+++ b/test/flight.test.js
@@ -24,6 +24,12 @@ describe('Flight Model', () => {
             expect(flight.completed).to.equal(true);
         });
 
+        it('should trim leading and trailing whitespace from string fields', () => {
+            const flight = new Flight({ ...baseSampleData, name: '  Spring 2026  ' });
+            expect(flight.name).to.equal('Spring 2026');
+            expect(flight.toJSON().name).to.equal('Spring 2026');
+        });
+
         it('should create a flight instance with default values when no data provided', () => {
             const flight = new Flight();
             expect(flight._id).to.equal('');

--- a/test/flights.test.js
+++ b/test/flights.test.js
@@ -329,6 +329,27 @@ describe('Flights Route Handlers', () => {
             expect(response.type).to.equal('Flight');
         });
 
+        it('should trim padded flight name before saving', async () => {
+            req.body = {
+                ...baseSampleData,
+                name: '  SSHF-Nov2011  '
+            };
+
+            let savedBody = null;
+            global.fetch.callsFake(async (url, options) => {
+                if (options?.method === 'POST') {
+                    savedBody = JSON.parse(options.body);
+                }
+                return { ok: true, json: async () => ({ id: 'new-id', rev: '1-abc' }) };
+            });
+
+            await createFlight(req, res);
+
+            expect(res.status.calledWith(201)).to.be.true;
+            expect(savedBody.name).to.equal('SSHF-Nov2011');
+            expect(res.json.firstCall.args[0].name).to.equal('SSHF-Nov2011');
+        });
+
         it('should set completed to false by default for new flights', async () => {
             // Remove completed from request body
             req.body = {
@@ -568,6 +589,21 @@ describe('Flights Route Handlers', () => {
             expect(res.json.called).to.be.true;
             const response = res.json.firstCall.args[0];
             expect(response._rev).to.equal('2-def');
+        });
+
+        it('should trim padded flight name on update', async () => {
+            req.body.name = '  SSHF-Updated  ';
+
+            let savedBody = null;
+            global.fetch.onSecondCall().callsFake(async (url, options) => {
+                savedBody = JSON.parse(options.body);
+                return { ok: true, json: async () => ({ id: 'test-id', rev: '2-def' }) };
+            });
+
+            await updateFlight(req, res);
+
+            expect(savedBody.name).to.equal('SSHF-Updated');
+            expect(res.json.firstCall.args[0].name).to.equal('SSHF-Updated');
         });
 
         it('should handle validation errors', async () => {

--- a/test/guardian.test.js
+++ b/test/guardian.test.js
@@ -52,6 +52,26 @@ describe('Guardian Model', () => {
             expect(guardian.address.city).to.equal('Springfield');
         });
 
+        it('should trim leading and trailing whitespace from string fields', () => {
+            const data = JSON.parse(JSON.stringify(sampleGuardianData));
+            data.name.first = '  Jane  ';
+            data.address.city = ' Springfield ';
+            data.flight.seat = ' 1B ';
+            const guardian = new Guardian(data);
+            expect(guardian.name.first).to.equal('Jane');
+            expect(guardian.address.city).to.equal('Springfield');
+            expect(guardian.flight.seat).to.equal('1B');
+        });
+
+        it('should not trim history array contents', () => {
+            const data = JSON.parse(JSON.stringify(sampleGuardianData));
+            data.name.first = '  Jane  ';
+            data.flight.history = [{ id: 't1', change: '  audit entry  ' }];
+            const guardian = new Guardian(data);
+            expect(guardian.name.first).to.equal('Jane');
+            expect(guardian.flight.history[0].change).to.equal('  audit entry  ');
+        });
+
         it('should create a guardian instance with default values when no data provided', () => {
             const guardian = new Guardian();
             expect(guardian.type).to.equal('Guardian');

--- a/test/guardians.test.js
+++ b/test/guardians.test.js
@@ -1966,6 +1966,24 @@ describe('Guardians Route Handlers', () => {
             });
         }
 
+        it('should trim padded apparel shirt size before validation', async () => {
+            req.body = { value: '  WM  ' };
+            global.fetch.onFirstCall().resolves({
+                ok: true,
+                json: async () => JSON.parse(JSON.stringify(baseDoc))
+            });
+            let savedDoc = null;
+            global.fetch.onSecondCall().callsFake(async (url, options) => {
+                savedDoc = JSON.parse(options.body);
+                return { ok: true, json: async () => ({ id: baseDoc._id, rev: '2-new' }) };
+            });
+
+            await updateGuardianApparelShirtSize(req, res);
+
+            expect(res.json.firstCall.args[0].apparel_shirt_size).to.equal('WM');
+            expect(savedDoc.apparel.shirt_size).to.equal('WM');
+        });
+
         it('should return 500 for non-404 fetch failure in helper', async () => {
             req.body = { value: true };
             global.fetch.onFirstCall().resolves({

--- a/test/trim_strings.test.js
+++ b/test/trim_strings.test.js
@@ -1,0 +1,100 @@
+import { expect } from 'chai';
+import { trimStringValues, trimIfString } from '../utils/trim_strings.js';
+
+describe('trim_strings utilities', () => {
+    describe('trimIfString', () => {
+        it('should trim leading and trailing whitespace from strings', () => {
+            expect(trimIfString('  hello  ')).to.equal('hello');
+        });
+
+        it('should return non-string values unchanged', () => {
+            expect(trimIfString(true)).to.equal(true);
+            expect(trimIfString(42)).to.equal(42);
+            expect(trimIfString(null)).to.equal(null);
+        });
+    });
+
+    describe('trimStringValues', () => {
+        it('should trim nested string fields', () => {
+            const input = {
+                name: { first: '  John  ', last: ' Smith ' },
+                address: { city: ' Springfield ' }
+            };
+            const result = trimStringValues(input);
+            expect(result.name.first).to.equal('John');
+            expect(result.name.last).to.equal('Smith');
+            expect(result.address.city).to.equal('Springfield');
+        });
+
+        it('should preserve internal spaces in strings', () => {
+            const input = { name: { first: '  Mary Ann  ' } };
+            const result = trimStringValues(input);
+            expect(result.name.first).to.equal('Mary Ann');
+        });
+
+        it('should not modify non-string values', () => {
+            const input = {
+                completed: true,
+                capacity: 100,
+                count: 0
+            };
+            const result = trimStringValues(input);
+            expect(result.completed).to.equal(true);
+            expect(result.capacity).to.equal(100);
+            expect(result.count).to.equal(0);
+        });
+
+        it('should skip history arrays and their contents', () => {
+            const input = {
+                name: { first: '  John  ' },
+                flight: {
+                    history: [
+                        { id: '2024-01-01', change: '  changed seat from: 1A  to: 2B  ' }
+                    ]
+                }
+            };
+            const result = trimStringValues(input);
+            expect(result.name.first).to.equal('John');
+            expect(result.flight.history[0].change).to.equal('  changed seat from: 1A  to: 2B  ');
+        });
+
+        it('should skip top-level history arrays', () => {
+            const history = [{ change: '  audit entry  ' }];
+            const input = {
+                name: '  test  ',
+                history
+            };
+            const result = trimStringValues(input);
+            expect(result.name).to.equal('test');
+            expect(result.history).to.equal(history);
+            expect(result.history[0].change).to.equal('  audit entry  ');
+        });
+
+        it('should skip arrays passed with a history parent key', () => {
+            const history = [{ change: '  audit entry  ' }];
+            const result = trimStringValues(history, 'history');
+            expect(result).to.equal(history);
+            expect(result[0].change).to.equal('  audit entry  ');
+        });
+
+        it('should return primitives unchanged', () => {
+            expect(trimStringValues(null)).to.equal(null);
+            expect(trimStringValues(undefined)).to.equal(undefined);
+            expect(trimStringValues('  hi  ')).to.equal('hi');
+        });
+
+        it('should not mutate the original object', () => {
+            const input = { name: { first: '  John  ' } };
+            const result = trimStringValues(input);
+            expect(input.name.first).to.equal('  John  ');
+            expect(result.name.first).to.equal('John');
+        });
+
+        it('should handle empty and whitespace-only strings', () => {
+            const input = { name: { first: '   ', last: '' } };
+            const result = trimStringValues(input);
+            expect(result.name.first).to.equal('');
+            expect(result.name.last).to.equal('');
+        });
+    });
+});

--- a/test/veteran.test.js
+++ b/test/veteran.test.js
@@ -58,6 +58,26 @@ describe('Veteran Model', () => {
             expect(veteran.address.city).to.equal('Springfield');
         });
 
+        it('should trim leading and trailing whitespace from string fields', () => {
+            const data = JSON.parse(JSON.stringify(sampleVeteranData));
+            data.name.first = '  John  ';
+            data.address.city = ' Springfield ';
+            data.flight.seat = ' 12A ';
+            const veteran = new Veteran(data);
+            expect(veteran.name.first).to.equal('John');
+            expect(veteran.address.city).to.equal('Springfield');
+            expect(veteran.flight.seat).to.equal('12A');
+        });
+
+        it('should not trim history array contents', () => {
+            const data = JSON.parse(JSON.stringify(sampleVeteranData));
+            data.name.first = '  John  ';
+            data.flight.history = [{ id: 't1', change: '  audit entry  ' }];
+            const veteran = new Veteran(data);
+            expect(veteran.name.first).to.equal('John');
+            expect(veteran.flight.history[0].change).to.equal('  audit entry  ');
+        });
+
         it('should create a veteran instance with default values when no data provided', () => {
             const veteran = new Veteran();
             expect(veteran.type).to.equal('');

--- a/test/veterans.test.js
+++ b/test/veterans.test.js
@@ -73,6 +73,28 @@ describe('Veterans Route Handlers', () => {
             expect(response._id).to.equal('new-id');
         });
 
+        it('should trim padded text fields before saving to CouchDB', async () => {
+            const paddedData = JSON.parse(JSON.stringify(baseSampleData));
+            paddedData.name.first = '  John  ';
+            paddedData.address.city = ' Springfield ';
+            req.body = paddedData;
+
+            let savedBody = null;
+            global.fetch.callsFake(async (url, options) => {
+                if (options?.method === 'POST') {
+                    savedBody = JSON.parse(options.body);
+                }
+                return { ok: true, json: async () => ({ id: 'new-id', rev: '1-abc' }) };
+            });
+
+            await createVeteran(req, res);
+
+            expect(res.status.calledWith(201)).to.be.true;
+            expect(savedBody.name.first).to.equal('John');
+            expect(savedBody.address.city).to.equal('Springfield');
+            expect(res.json.firstCall.args[0].name.first).to.equal('John');
+        });
+
         it('should handle validation errors', async () => {
             const invalidData = JSON.parse(JSON.stringify(baseSampleData));
             invalidData.name.first = '12';
@@ -572,6 +594,26 @@ describe('Veterans Route Handlers', () => {
             expect(savedDoc.flight.seat).to.equal('14B');
             expect(savedDoc.flight.history.length).to.equal(1);
             expect(savedDoc.flight.history[0].change).to.include('changed seat from: 10A to: 14B');
+        });
+
+        it('should trim padded seat value before saving', async () => {
+            req.body = { value: '  14B  ' };
+
+            global.fetch.onFirstCall().resolves({
+                ok: true,
+                json: async () => JSON.parse(JSON.stringify(mockVeteranDoc))
+            });
+
+            let savedDoc = null;
+            global.fetch.onSecondCall().callsFake(async (url, options) => {
+                savedDoc = JSON.parse(options.body);
+                return { ok: true, json: async () => ({ id: 'vet-123', rev: '2-xyz' }) };
+            });
+
+            await updateVeteranSeat(req, res);
+
+            expect(res.json.firstCall.args[0].seat).to.equal('14B');
+            expect(savedDoc.flight.seat).to.equal('14B');
         });
 
         it('should update veteran seat with empty old value', async () => {

--- a/utils/trim_strings.js
+++ b/utils/trim_strings.js
@@ -1,0 +1,36 @@
+const SKIP_KEYS = new Set(['history']);
+
+export function trimIfString(value) {
+    return typeof value === 'string' ? value.trim() : value;
+}
+
+export function trimStringValues(value, parentKey = null) {
+    if (typeof value === 'string') {
+        return value.trim();
+    }
+
+    if (value === null || value === undefined) {
+        return value;
+    }
+
+    if (Array.isArray(value)) {
+        if (parentKey && SKIP_KEYS.has(parentKey)) {
+            return value;
+        }
+        return value.map(item => trimStringValues(item));
+    }
+
+    if (typeof value === 'object') {
+        const result = {};
+        for (const [key, child] of Object.entries(value)) {
+            if (SKIP_KEYS.has(key)) {
+                result[key] = child;
+            } else {
+                result[key] = trimStringValues(child, key);
+            }
+        }
+        return result;
+    }
+
+    return value;
+}


### PR DESCRIPTION
## Summary
- Add shared `trimStringValues` / `trimIfString` utilities that trim user-supplied text before persistence while skipping `history` audit arrays
- Apply normalization in Veteran, Guardian, and Flight model constructors and in veteran/guardian patch, seat, and bus route handlers
- Add unit and route tests covering padded input on create, update, patch, and seat paths

Closes #68

## Test plan
- [x] `npm test` (full suite passes)
- [x] Verify padded names, seats, and enum values (e.g. `"  WM  "`) are trimmed before CouchDB writes
- [x] Verify `history` audit entries are not modified by trimming
