### PR TITLE
Prod environment support: env-driven config, prod promotion pipeline, deployment docs

### DIFF
--- a/.github/workflows/cloudrun-promote-prd.yml
+++ b/.github/workflows/cloudrun-promote-prd.yml
@@ -1,0 +1,133 @@
+name: Promote to Cloud Run Production
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Existing git tag to promote (e.g. v1.0.0)'
+        required: true
+
+concurrency: production-deploy
+
+env:
+  # Dev registry where merge-to-main builds land (tagged sha-<commit>).
+  DEV_IMAGE_REPO: us-central1-docker.pkg.dev/sshf-api-dev/cloud-run-source-deploy/sshf-api
+  # Prod-owned registry that holds promoted, version-tagged images.
+  PROD_IMAGE_REPO: us-central1-docker.pkg.dev/sshf-api-prd/sshf-api/sshf-api
+  PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+  SERVICE_NAME: ${{ secrets.GCP_SERVICE_NAME }}
+  REGION: ${{ secrets.GCP_REGION }}
+  WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+  SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+jobs:
+  promote:
+    runs-on: 'ubuntu-latest'
+    # Requires the "production" GitHub environment (approval gate +
+    # environment-scoped GCP_* secrets pointing at sshf-api-prd).
+    environment: 'production'
+
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@v4'
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: 'Resolve version and commit'
+        id: 'version'
+        run: |
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            VERSION="${{ github.event.release.tag_name }}"
+            COMMIT="${{ github.sha }}"
+          else
+            VERSION="${{ inputs.version }}"
+            COMMIT=$(git rev-list -n 1 "$VERSION")
+          fi
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Version '$VERSION' must be a semver tag like v1.2.3"
+            exit 1
+          fi
+          # Cloud Run revision tags cannot contain dots.
+          REVISION_TAG="${VERSION//./-}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "commit=$COMMIT" >> "$GITHUB_OUTPUT"
+          echo "revision_tag=$REVISION_TAG" >> "$GITHUB_OUTPUT"
+
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v3'
+        with:
+          workload_identity_provider: '${{ env.WORKLOAD_IDENTITY_PROVIDER }}'
+          service_account: '${{ env.SERVICE_ACCOUNT }}'
+          token_format: 'access_token'
+          create_credentials_file: true
+          export_environment_variables: true
+
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v3'
+
+      - name: 'Resolve dev image digest for released commit'
+        id: 'digest'
+        run: |
+          COMMIT="${{ steps.version.outputs.commit }}"
+          DIGEST=$(gcloud artifacts docker images describe \
+            "${DEV_IMAGE_REPO}:sha-${COMMIT}" \
+            --format 'value(image_summary.digest)' 2>/dev/null) || true
+          if [[ -z "$DIGEST" ]]; then
+            echo "::error::No dev image tagged sha-${COMMIT} in ${DEV_IMAGE_REPO}. Make sure the release commit was merged to main and the dev deploy workflow completed (it tags built images with the commit SHA)."
+            exit 1
+          fi
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+
+      - name: 'Set up crane'
+        uses: 'imjasonh/setup-crane@v0.4'
+
+      - name: 'Copy image digest to production registry'
+        run: |
+          gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+          crane cp \
+            "${DEV_IMAGE_REPO}@${{ steps.digest.outputs.digest }}" \
+            "${PROD_IMAGE_REPO}:${{ steps.version.outputs.version }}"
+
+      - name: 'Deploy to Cloud Run (no traffic)'
+        id: 'deploy'
+        uses: 'google-github-actions/deploy-cloudrun@v3'
+        with:
+          project_id: '${{ env.PROJECT_ID }}'
+          service: '${{ env.SERVICE_NAME }}'
+          region: '${{ env.REGION }}'
+          image: '${{ env.PROD_IMAGE_REPO }}@${{ steps.digest.outputs.digest }}'
+          no_traffic: true
+          tag: '${{ steps.version.outputs.revision_tag }}'
+
+      - name: 'Smoke test tagged revision'
+        run: |
+          TAG="${{ steps.version.outputs.revision_tag }}"
+          TAG_URL=$(gcloud run services describe "${SERVICE_NAME}" \
+            --region "${REGION}" --project "${PROJECT_ID}" --format json \
+            | jq -r --arg t "$TAG" '.status.traffic[] | select(.tag==$t) | .url')
+          if [[ -z "$TAG_URL" || "$TAG_URL" == "null" ]]; then
+            echo "::error::Could not resolve URL for revision tag $TAG"
+            exit 1
+          fi
+          echo "Smoke testing $TAG_URL"
+          # /api-docs is public; a successful response proves the revision boots.
+          curl -fsSL --retry 3 --retry-delay 5 "$TAG_URL/api-docs/" -o /dev/null
+          echo "Smoke test passed"
+
+      - name: 'Shift 100% traffic to new revision'
+        run: |
+          gcloud run services update-traffic "${SERVICE_NAME}" \
+            --region "${REGION}" --project "${PROJECT_ID}" --to-latest
+
+      - name: 'Show output'
+        run: |-
+          echo "Promoted ${{ steps.version.outputs.version }} (${{ steps.digest.outputs.digest }})"
+          echo ${{ steps.deploy.outputs.url }}

--- a/.github/workflows/cloudrun-source.yml
+++ b/.github/workflows/cloudrun-source.yml
@@ -49,7 +49,7 @@ jobs:
       # including authenticating via a JSON credentials file.
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v2'
+        uses: 'google-github-actions/auth@v3'
         with:
           workload_identity_provider: '${{ env.WORKLOAD_IDENTITY_PROVIDER }}'
           service_account: '${{ env.SERVICE_ACCOUNT }}'
@@ -58,17 +58,31 @@ jobs:
           export_environment_variables: true
 
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v2'
+        uses: 'google-github-actions/setup-gcloud@v3'
 
       - name: 'Deploy to Cloud Run'
         id: 'deploy'
-        uses: 'google-github-actions/deploy-cloudrun@v2'
+        uses: 'google-github-actions/deploy-cloudrun@v3'
         with:
           project_id: '${{ env.PROJECT_ID }}'
           service: '${{ env.SERVICE_NAME }}'
           region: '${{ env.REGION }}'
           # NOTE: If using a different source folder, update the image name below:
           source: './'
+
+      # Tag the image built by this deploy with the commit SHA so the
+      # production promotion workflow can map a release tag back to the
+      # exact image digest that was tested in dev.
+      - name: 'Tag deployed image with commit SHA'
+        run: |
+          REVISION=$(gcloud run services describe "${SERVICE_NAME}" \
+            --region "${REGION}" --project "${PROJECT_ID}" \
+            --format 'value(status.latestCreatedRevisionName)')
+          IMAGE=$(gcloud run revisions describe "${REVISION}" \
+            --region "${REGION}" --project "${PROJECT_ID}" \
+            --format 'value(status.imageDigest)')
+          gcloud artifacts docker tags add "${IMAGE}" \
+            "${REGION}-docker.pkg.dev/${PROJECT_ID}/cloud-run-source-deploy/${SERVICE_NAME}:sha-${GITHUB_SHA}"
 
       # If required, use the Cloud Run URL output in later steps
       - name: 'Show output'

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ coverage/
 .env
 *.swp
 *~
+
+# AI Tools
+.cursor/skills/

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Required environment variables:
 | `DB_NAME` | Database name |
 | `DB_USER` | CouchDB username |
 | `DB_PASS` | CouchDB password |
+| `ALLOWED_ORIGINS` | Comma-separated CORS allowed origins (defaults to `http://localhost:3000,http://localhost:8080`) |
+| `API_URL` | Public API base URL for OpenAPI/Swagger (defaults to `http://localhost:8080`) |
+| `GOOGLE_CLIENT_ID` | Google OAuth client ID for Swagger UI authentication |
 | `GOOGLE_SERVICE_ACCOUNT_EMAIL` | Service account email (local dev) |
 | `GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY` | Service account private key (local dev) |
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,15 @@ Use a conservative update flow so GitHub alerts can be cleared without pulling i
 
 Avoid manually editing `package-lock.json`. If the lockfile truly needs to be regenerated, delete `node_modules` and `package-lock.json`, run `npm install`, and then re-run the full verification flow before committing the new lockfile.
 
+## Deployment
+
+Deployments are fully automated with GitHub Actions:
+
+- Merging a PR to `main` deploys to the **dev** environment (`sshf-api-dev`).
+- Publishing a GitHub Release tagged `vX.Y.Z` promotes the exact dev-tested image to **production** (`sshf-api-prd`), behind a manual approval gate.
+
+See the [CI/CD and Deployment Guide](docs/DEPLOYMENT.md) for the full process: release preparation, promotion steps, post-release verification, rollback, and environment configuration.
+
 ## API Documentation
 
 Interactive API documentation is available at `/api-docs` when the server is running.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,226 @@
+# CI/CD and Deployment Guide
+
+This document describes the full path code takes from a developer's branch to
+production, what must be done during development to keep a release possible,
+how a release is promoted to production, and how to verify and roll back a
+release. It is written for both developers and administrators.
+
+## Environments
+
+| | Development | Production |
+|---|---|---|
+| GCP project | `sshf-api-dev` | `sshf-api-prd` |
+| Service URL | https://sshf-api-330507742215.us-central1.run.app | https://sshf-api-928260206537.us-central1.run.app |
+| Cloud Run service | `sshf-api` (us-central1) | `sshf-api` (us-central1) |
+| Runtime service account | `sshf-api-acc-dev@sshf-api-dev.iam.gserviceaccount.com` | `sshf-api-acc-prd@sshf-api-prd.iam.gserviceaccount.com` |
+| Deploy service account | `github-service-account@sshf-api-dev.iam.gserviceaccount.com` | `github-service-account@sshf-api-prd.iam.gserviceaccount.com` |
+| Image registry | `us-central1-docker.pkg.dev/sshf-api-dev/cloud-run-source-deploy/sshf-api` | `us-central1-docker.pkg.dev/sshf-api-prd/sshf-api/sshf-api` |
+| Deployed by | Merge to `main` | Published GitHub Release (with approval) |
+| Secrets | `sshf-api-*-dev` in dev Secret Manager | `sshf-api-*-prd` in prod Secret Manager |
+
+Both services are publicly invokable; authentication and authorization happen
+inside the application (Google OAuth + Workspace group membership).
+
+## Pipeline overview
+
+The core principle is **build once, promote by digest**. Production never
+rebuilds from source; it receives the exact container image that was built,
+deployed, and tested in dev.
+
+```mermaid
+flowchart LR
+    pr[Pull request] --> tests[run-tests.yml]
+    tests --> merge[Merge to main]
+    merge --> devDeploy[cloudrun-source.yml: source deploy to dev]
+    devDeploy --> shaTag[Image tagged sha-COMMIT in dev registry]
+    release[GitHub Release vX.Y.Z] --> gate[production environment approval]
+    gate --> promote[cloudrun-promote-prd.yml]
+    shaTag -. digest lookup .-> promote
+    promote --> copy[Copy digest to prod registry as vX.Y.Z]
+    copy --> deploy[Deploy to prod with no traffic]
+    deploy --> smoke[Smoke test tagged revision]
+    smoke --> shift[Shift 100 percent traffic]
+```
+
+Workflows involved (all in `.github/workflows/`):
+
+| Workflow | Trigger | What it does |
+|---|---|---|
+| `run-tests.yml` | Pull request to `main` | Installs dependencies and runs the mocha suite |
+| `cloudrun-source.yml` | PR merged to `main` | Source-deploys to dev Cloud Run (Buildpacks), then tags the built image `sha-<commit>` in the dev registry |
+| `cloudrun-promote-prd.yml` | GitHub Release published (or manual dispatch) | Promotes the dev-built image digest to production |
+
+## For developers: during development
+
+1. Branch from `main`, make changes with tests, and open a PR. The test
+   workflow must pass before merge.
+2. **Never hardcode environment-specific values** (URLs, origins, client IDs).
+   Runtime configuration comes from environment variables backed by Secret
+   Manager. If you add a new environment variable:
+   - Read it via `process.env` with a sensible local-dev fallback.
+   - Document it in `env.example` and the README table.
+   - Tell an administrator so the variable/secret can be added to **both** the
+     dev and prod Cloud Run services before the change is released. A release
+     whose code requires a variable that prod does not have will fail or
+     misbehave in production.
+3. Merging to `main` automatically deploys to dev. Verify your change on the
+   dev service before considering it releasable.
+4. The merge workflow tags the built image with the merge commit SHA. This tag
+   is what makes the commit promotable to production later — if the dev deploy
+   workflow failed, the release promotion for that commit will also fail, so
+   keep `main` green.
+
+## Preparing a release
+
+1. Decide the new semver version `vX.Y.Z`:
+   - **Patch** — bug fixes, no API surface change
+   - **Minor** — new endpoints/fields, backward compatible
+   - **Major** — breaking API changes
+2. Update the version in **both** places, via a normal PR:
+   - `package.json` → `"version"`
+   - `swagger/swagger.js` → `info.version`
+3. Merge that PR and let the dev deploy finish. The version bump commit (or
+   the last commit on `main` you intend to ship) is what gets tagged.
+4. Sanity-check dev: `https://sshf-api-330507742215.us-central1.run.app/openapi.json`
+   should report the new version, and the app should work end to end.
+
+## Releasing to production
+
+1. In GitHub: **Releases → Draft a new release**. Create a new tag `vX.Y.Z`
+   targeting `main` (the tag must match `v[0-9]+.[0-9]+.[0-9]+`). Write brief
+   release notes and **Publish**.
+2. The `Promote to Cloud Run Production` workflow starts and pauses at the
+   `production` environment gate. A required reviewer (administrator) approves
+   it under **Actions → the running workflow → Review deployments**.
+3. After approval the workflow, running as the prod deploy service account via
+   Workload Identity Federation:
+   1. Resolves the dev image digest for the released commit (via the
+      `sha-<commit>` tag).
+   2. Copies that exact digest to the prod registry, tagged `vX.Y.Z`.
+   3. Deploys it to prod Cloud Run with **no traffic** and a revision tag
+      (`v1-2-3` — dots become dashes).
+   4. Smoke-tests the tagged revision's private URL (`/api-docs/` must return
+      success).
+   5. Shifts 100% of traffic to the new revision.
+
+If any step fails, production traffic remains on the previous revision.
+
+### Manual promotion
+
+The workflow can also be run by hand: **Actions → Promote to Cloud Run
+Production → Run workflow**, entering an existing tag (e.g. `v1.0.0`). This is
+useful for re-promoting an older version (see Rollback).
+
+## Post-release verification
+
+Anyone can verify; no GCP access needed for the first three:
+
+1. **Workflow green** — the promote run shows all steps succeeded, including
+   the smoke test and the traffic shift.
+2. **Version arrived** — `https://sshf-api-928260206537.us-central1.run.app/openapi.json`
+   reports the released version in `info.version`.
+3. **App works** — open `https://sshf-api-928260206537.us-central1.run.app/api-docs/`,
+   sign in with a production Google account, and exercise a protected endpoint
+   (e.g. `GET /user/hasgroup`). Roles should reflect your Workspace groups.
+   Note: the API caches a signed-in token's roles for 30 minutes; use a fresh
+   sign-in when validating authorization changes.
+
+Administrators can additionally confirm from the CLI:
+
+```bash
+# The serving revision and its image digest should match the release
+gcloud run services describe sshf-api --region us-central1 --project sshf-api-prd \
+  --format "value(status.latestReadyRevisionName, status.traffic)"
+
+# Recent errors (should be quiet)
+gcloud logging read "resource.type=cloud_run_revision AND resource.labels.service_name=sshf-api AND severity>=ERROR" \
+  --project sshf-api-prd --freshness=1h --limit 20
+```
+
+## Rollback
+
+Two options, in order of preference:
+
+1. **Shift traffic back** (fastest, no new deploy). Cloud Run keeps previous
+   revisions:
+
+```bash
+gcloud run revisions list --service sshf-api --region us-central1 --project sshf-api-prd
+gcloud run services update-traffic sshf-api --region us-central1 --project sshf-api-prd \
+  --to-revisions <previous-revision-name>=100
+```
+
+2. **Re-promote an older version** — run the promote workflow manually with a
+   previous tag. Promoted images are retained in the prod registry under their
+   version tags, and revisions are immutable, so any released version can be
+   restored exactly.
+
+## Configuration and secrets (administrators)
+
+- Environment variable **names** are identical in dev and prod; only the
+  Secret Manager secret names differ (`-dev` vs `-prd` suffix).
+- The mapping of env vars to secrets lives **on the Cloud Run service**, not in
+  the repository. Deploys that only change the image preserve it.
+
+| Env var | Dev secret | Prod secret |
+|---|---|---|
+| `DB_URL` | `sshf-api-db-url-dev` | `sshf-api-db-url-prd` |
+| `DB_NAME` | `sshf-api-db-name-dev` | `sshf-api-db-name-prd` |
+| `DB_USER` | `sshf-api-db-user-dev` | `sshf-api-db-user-prd` |
+| `DB_PASS` | `sshf-api-db-pass-dev` | `sshf-api-db-pass-prd` |
+| `API_URL` | `sshf-api-url-dev` | `sshf-api-url-prd` |
+| `GOOGLE_CLIENT_ID` | `sshf-api-auth-clientid-dev` | `sshf-api-auth-clientid-prd` |
+| `ALLOWED_ORIGINS` | plain env var on the service | plain env var on the service |
+
+- Secrets are referenced as `:latest`, but a running revision does **not**
+  pick up new secret versions. After adding a secret version, force a new
+  revision to apply it:
+
+```bash
+gcloud run services update sshf-api --region us-central1 --project sshf-api-prd
+```
+
+- To change `ALLOWED_ORIGINS` (for example when the production UI gets its
+  custom domain):
+
+```bash
+gcloud run services update sshf-api --region us-central1 --project sshf-api-prd \
+  --update-env-vars "^;^ALLOWED_ORIGINS=https://sshf-ui-824787296892.us-central1.run.app,https://sshf-api-928260206537.us-central1.run.app"
+```
+
+## Infrastructure reference (administrators)
+
+One-time setup that the pipeline depends on. If any of this is removed, the
+promotion workflow breaks:
+
+- **Workload Identity Federation** (per project): pool `github-pool` with OIDC
+  provider `sshf-api` for `token.actions.githubusercontent.com`, restricted to
+  this repository by numeric owner/repo ID. The GitHub workflows authenticate
+  as the project's `github-service-account` with no stored keys.
+- **Prod deploy SA roles**: `run.admin` on the prod project,
+  `iam.serviceAccountUser` on the prod runtime SA, `artifactregistry.writer`
+  on the prod `sshf-api` repository, and `artifactregistry.reader` on the dev
+  `cloud-run-source-deploy` repository.
+- **Dev deploy SA extra role**: `artifactregistry.writer` on the dev registry
+  (needed for the post-deploy `sha-<commit>` tagging step).
+- **Prod runtime SA**: `secretmanager.secretAccessor` on the prod project and
+  the **Groups Reader** admin role in Google Workspace (Admin console → Admin
+  roles). The **Admin SDK API** (`admin.googleapis.com`) must be enabled on
+  the prod project or group lookups silently return no roles.
+- **GitHub `production` environment**: required reviewer(s) plus the
+  environment secrets `GCP_PROJECT_ID`, `GCP_SERVICE_NAME`, `GCP_REGION`,
+  `GCP_WORKLOAD_IDENTITY_PROVIDER`, `GCP_SERVICE_ACCOUNT` (prod values).
+  Repository-level secrets with the same names hold the dev values used by
+  the merge-to-main deploy.
+
+## Troubleshooting
+
+| Symptom | Likely cause / fix |
+|---|---|
+| Promote fails: "No dev image tagged sha-…" | The released commit was never deployed to dev, or the dev deploy workflow failed before tagging. Re-run the dev deploy (or merge the commit), then re-run the promotion. |
+| Promote never asks for approval | The `production` GitHub environment or its required reviewer is missing. |
+| Auth step fails with a token/OIDC error | Workload Identity Federation provider, its attribute condition, or the SA binding was changed. Compare against the Infrastructure reference above. |
+| Smoke test fails, traffic unchanged | The new revision does not boot or `/api-docs/` errors. Check revision logs in the prod project; production users are unaffected. Fix and release again. |
+| Users authenticate but have no roles | Admin SDK API disabled in the project, runtime SA missing the Workspace Groups Reader role, or a cached token (30-minute cache — re-sign-in). |
+| New secret value not taking effect | Revisions pin secret versions at deploy time. Force a new revision (see Configuration and secrets). |
+| CORS errors from the UI | The UI origin is missing from the service's `ALLOWED_ORIGINS` env var. |

--- a/env.example
+++ b/env.example
@@ -2,3 +2,12 @@ DB_URL=your_couchdb_url_here
 DB_NAME=your_db_name_here
 DB_USER=your_database_username
 DB_PASS=your_database_password
+
+# Comma-separated list of allowed CORS origins (defaults to localhost:3000 and localhost:8080)
+ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8080,https://sshf-ui-593951006010.us-central1.run.app,https://sshf-api-330507742215.us-central1.run.app
+
+# Public API base URL used in OpenAPI/Swagger server list (defaults to http://localhost:8080)
+API_URL=http://localhost:8080
+
+# Google OAuth client ID for Swagger UI authentication
+GOOGLE_CLIENT_ID=your_google_client_id_here

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ import { google } from 'googleapis';
 import { specs } from './swagger/swagger.js';
 import { swaggerUiServe, swaggerUiSetup } from './swagger/swagger-ui.js';
 import { dbSession } from './utils/db.js';
+import { buildCorsOptions } from './utils/cors.js';
 
 // Import route handlers
 import { getMessage, postMessage } from './routes/msg.js';
@@ -60,27 +61,8 @@ import { exportFlightCsv, exportCallCenterFollowUpCsv, exportTourLeadCsv } from 
 const app = express();
 const port = 8080;
 
-// Define allowed origins for CORS
-const allowedOrigins = [
-    'http://localhost:3000',
-    'http://localhost:8080',
-    'https://sshf-ui-593951006010.us-central1.run.app',
-    'https://sshf-api-330507742215.us-central1.run.app'
-];
-
-// Configure CORS options
-const corsOptions = {
-    origin: function (origin, callback) {
-        if (!origin || allowedOrigins.indexOf(origin) !== -1) {
-            callback(null, true);
-        } else {
-            callback(new Error('Not allowed by CORS'));
-        }
-    }
-};
-
 // Enable CORS for all routes with specific options
-app.use(cors(corsOptions));
+app.use(cors(buildCorsOptions()));
 
 // In-memory cache for user authentication
 const userCache = new Map();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sshf-api",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/swagger/swagger.js
+++ b/swagger/swagger.js
@@ -52,6 +52,15 @@ const extractSwaggerPaths = (dir) => {
   return paths;
 };
 
+export function getServers() {
+  return [
+    {
+      url: process.env.API_URL || 'http://localhost:8080',
+      description: 'API Server',
+    },
+  ];
+}
+
 const definition = {
   openapi: '3.0.0',
   info: {
@@ -59,20 +68,7 @@ const definition = {
     version: '1.0.0',
     description: 'API for managing veterans documents with Google authentication',
   },
-  servers: [
-    {
-      url: process.env.API_URL || 'http://localhost:8080',
-      description: 'API Server',
-    },
-    {
-      url: 'http://localhost:8080',
-      description: 'Force local API Server',
-    },
-    {
-      url: 'https://sshf-api-330507742215.us-central1.run.app',
-      description: 'Force Dev Environment API Server',
-    },
-  ],
+  servers: getServers(),
   components: {
     securitySchemes: {
       GoogleAuth: {

--- a/swagger/swagger.js
+++ b/swagger/swagger.js
@@ -65,7 +65,7 @@ const definition = {
   openapi: '3.0.0',
   info: {
     title: 'SSHF API',
-    version: '1.0.0',
+    version: '1.0.1',
     description: 'API for managing veterans documents with Google authentication',
   },
   servers: getServers(),

--- a/test/cors.test.js
+++ b/test/cors.test.js
@@ -1,0 +1,100 @@
+import { expect } from 'chai';
+import { getAllowedOrigins, buildCorsOptions } from '../utils/cors.js';
+
+describe('CORS utilities', () => {
+    const originalAllowedOrigins = process.env.ALLOWED_ORIGINS;
+
+    afterEach(() => {
+        if (originalAllowedOrigins === undefined) {
+            delete process.env.ALLOWED_ORIGINS;
+        } else {
+            process.env.ALLOWED_ORIGINS = originalAllowedOrigins;
+        }
+    });
+
+    describe('getAllowedOrigins', () => {
+        it('returns localhost defaults when ALLOWED_ORIGINS is unset', () => {
+            delete process.env.ALLOWED_ORIGINS;
+            expect(getAllowedOrigins()).to.deep.equal([
+                'http://localhost:3000',
+                'http://localhost:8080'
+            ]);
+        });
+
+        it('returns localhost defaults when ALLOWED_ORIGINS is empty', () => {
+            process.env.ALLOWED_ORIGINS = '';
+            expect(getAllowedOrigins()).to.deep.equal([
+                'http://localhost:3000',
+                'http://localhost:8080'
+            ]);
+        });
+
+        it('returns localhost defaults when ALLOWED_ORIGINS is whitespace only', () => {
+            process.env.ALLOWED_ORIGINS = '   ';
+            expect(getAllowedOrigins()).to.deep.equal([
+                'http://localhost:3000',
+                'http://localhost:8080'
+            ]);
+        });
+
+        it('parses a comma-separated list of origins', () => {
+            process.env.ALLOWED_ORIGINS =
+                'http://localhost:3000,https://example.com,https://api.example.com';
+            expect(getAllowedOrigins()).to.deep.equal([
+                'http://localhost:3000',
+                'https://example.com',
+                'https://api.example.com'
+            ]);
+        });
+
+        it('trims whitespace around entries', () => {
+            process.env.ALLOWED_ORIGINS =
+                ' http://localhost:3000 , https://example.com ';
+            expect(getAllowedOrigins()).to.deep.equal([
+                'http://localhost:3000',
+                'https://example.com'
+            ]);
+        });
+
+        it('ignores empty entries from trailing or consecutive commas', () => {
+            process.env.ALLOWED_ORIGINS = 'http://localhost:3000,,https://example.com,';
+            expect(getAllowedOrigins()).to.deep.equal([
+                'http://localhost:3000',
+                'https://example.com'
+            ]);
+        });
+    });
+
+    describe('buildCorsOptions', () => {
+        it('allows requests with no origin', (done) => {
+            process.env.ALLOWED_ORIGINS = 'http://localhost:3000';
+            const { origin } = buildCorsOptions();
+            origin(undefined, (err, allowed) => {
+                expect(err).to.be.null;
+                expect(allowed).to.be.true;
+                done();
+            });
+        });
+
+        it('allows a listed origin', (done) => {
+            process.env.ALLOWED_ORIGINS = 'http://localhost:3000,https://example.com';
+            const { origin } = buildCorsOptions();
+            origin('https://example.com', (err, allowed) => {
+                expect(err).to.be.null;
+                expect(allowed).to.be.true;
+                done();
+            });
+        });
+
+        it('rejects an unlisted origin with Not allowed by CORS', (done) => {
+            process.env.ALLOWED_ORIGINS = 'http://localhost:3000';
+            const { origin } = buildCorsOptions();
+            origin('https://evil.example.com', (err, allowed) => {
+                expect(err).to.be.an('error');
+                expect(err.message).to.equal('Not allowed by CORS');
+                expect(allowed).to.be.undefined;
+                done();
+            });
+        });
+    });
+});

--- a/test/swagger-servers.test.js
+++ b/test/swagger-servers.test.js
@@ -1,0 +1,48 @@
+import { expect } from 'chai';
+import { getServers } from '../swagger/swagger.js';
+
+describe('Swagger servers configuration', () => {
+    const originalApiUrl = process.env.API_URL;
+
+    afterEach(() => {
+        if (originalApiUrl === undefined) {
+            delete process.env.API_URL;
+        } else {
+            process.env.API_URL = originalApiUrl;
+        }
+    });
+
+    it('returns a single server with localhost fallback when API_URL is unset', () => {
+        delete process.env.API_URL;
+        expect(getServers()).to.deep.equal([
+            {
+                url: 'http://localhost:8080',
+                description: 'API Server'
+            }
+        ]);
+    });
+
+    it('returns a single server using API_URL when set', () => {
+        process.env.API_URL = 'https://sshf-api.example.run.app';
+        expect(getServers()).to.deep.equal([
+            {
+                url: 'https://sshf-api.example.run.app',
+                description: 'API Server'
+            }
+        ]);
+    });
+
+    it('does not include a hardcoded dev environment server entry', () => {
+        delete process.env.API_URL;
+        const servers = getServers();
+        const urls = servers.map((server) => server.url);
+        expect(urls).to.not.include('https://sshf-api-330507742215.us-central1.run.app');
+    });
+
+    it('does not include a separate force-local server entry', () => {
+        process.env.API_URL = 'https://sshf-api.example.run.app';
+        const servers = getServers();
+        expect(servers).to.have.lengthOf(1);
+        expect(servers[0].description).to.equal('API Server');
+    });
+});

--- a/utils/cors.js
+++ b/utils/cors.js
@@ -1,0 +1,28 @@
+const DEFAULT_ORIGINS = [
+    'http://localhost:3000',
+    'http://localhost:8080'
+];
+
+export function getAllowedOrigins() {
+    const raw = process.env.ALLOWED_ORIGINS;
+    if (!raw || raw.trim() === '') {
+        return [...DEFAULT_ORIGINS];
+    }
+    return raw
+        .split(',')
+        .map((entry) => entry.trim())
+        .filter((entry) => entry.length > 0);
+}
+
+export function buildCorsOptions() {
+    const allowedOrigins = getAllowedOrigins();
+    return {
+        origin(origin, callback) {
+            if (!origin || allowedOrigins.indexOf(origin) !== -1) {
+                callback(null, true);
+            } else {
+                callback(new Error('Not allowed by CORS'));
+            }
+        }
+    };
+}


### PR DESCRIPTION
## Summary
- Make CORS origins env-driven (`ALLOWED_ORIGINS` via new `utils/cors.js`) and derive Swagger servers from `API_URL`, so one container image can serve dev and prod (13 new tests, suite at 919 passing).
- Upgrade dev deploy workflow to google-github-actions v3 and tag built images with the merge commit SHA.
- Add `cloudrun-promote-prd.yml`: release-triggered (`vX.Y.Z`) promotion that copies the dev-tested image digest to the prod registry, deploys to `sshf-api-prd` with no traffic behind the `production` approval gate, smoke-tests, then shifts traffic.
- Add `docs/DEPLOYMENT.md` (full CI/CD guide) linked from the README; document new env vars in `env.example`.

## Test plan
- [x] `npm test` passes locally (919 passing)
- [x] Prod infrastructure provisioned and bootstrap revision verified (Swagger 200, protected routes 401)
- [x] After merge: dev deploy runs green and tags the image `sha-<commit>`
- [x] Publish `v1.0.0` release and approve the production promotion

Made with [Cursor](https://cursor.com)