### PR TITLE
Validate access token audience (reject cross-client tokens)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ Required environment variables:
 | `DB_PASS` | CouchDB password |
 | `ALLOWED_ORIGINS` | Comma-separated CORS allowed origins (defaults to `http://localhost:3000,http://localhost:8080`) |
 | `API_URL` | Public API base URL for OpenAPI/Swagger (defaults to `http://localhost:8080`) |
-| `GOOGLE_CLIENT_ID` | Google OAuth client ID for Swagger UI authentication |
+| `GOOGLE_CLIENT_ID` | Google OAuth client ID for Swagger UI auth, and the client whose access tokens the API accepts (audience validation) |
+| `ALLOWED_CLIENT_IDS` | Optional. Comma-separated OAuth client IDs accepted for token audience validation (overrides `GOOGLE_CLIENT_ID` when set) |
+| `ALLOWED_EMAIL_DOMAINS` | Optional. Comma-separated email domains permitted to access the API; unset disables the domain check |
 | `GOOGLE_SERVICE_ACCOUNT_EMAIL` | Service account email (local dev) |
 | `GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY` | Service account private key (local dev) |
 
@@ -103,6 +105,24 @@ Deployments are fully automated with GitHub Actions:
 - Publishing a GitHub Release tagged `vX.Y.Z` promotes the exact dev-tested image to **production** (`sshf-api-prd`), behind a manual approval gate.
 
 See the [CI/CD and Deployment Guide](docs/DEPLOYMENT.md) for the full process: release preparation, promotion steps, post-release verification, rollback, and environment configuration.
+
+## Authentication & Authorization
+
+Protected endpoints require a Google OAuth2 access token as a Bearer token.
+The API enforces two checks before a request proceeds:
+
+1. **Audience validation** — the token is introspected and rejected with `401`
+   unless it was issued for this API's OAuth client (`GOOGLE_CLIENT_ID`, or any
+   ID in `ALLOWED_CLIENT_IDS`). This ensures a valid Google token minted for
+   some other application cannot be replayed against this API.
+2. **Email domain (optional)** — when `ALLOWED_EMAIL_DOMAINS` is set, an
+   authenticated user whose verified email falls outside those domains receives
+   `403`.
+
+Group memberships are attached to the request for endpoints that report them
+(e.g. `GET /user/hasgroup`). Responses: `401` for a missing, invalid, expired,
+or wrong-audience token; `403` for a permitted-token account that is not
+allowed; `503` if token introspection is temporarily unavailable.
 
 ## API Documentation
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -188,6 +188,25 @@ gcloud run services update sshf-api --region us-central1 --project sshf-api-prd 
   --update-env-vars "^;^ALLOWED_ORIGINS=https://sshf-ui-824787296892.us-central1.run.app,https://sshf-api-928260206537.us-central1.run.app"
 ```
 
+- **Token audience validation.** The API rejects any access token not issued
+  for its OAuth client (`GOOGLE_CLIENT_ID`). The UI and Swagger currently share
+  the same client ID, so no extra configuration is needed. If a separate UI
+  client is ever introduced, add its ID to `ALLOWED_CLIENT_IDS`
+  (comma-separated, plain env var) so both are accepted:
+
+```bash
+gcloud run services update sshf-api --region us-central1 --project sshf-api-prd \
+  --update-env-vars "^;^ALLOWED_CLIENT_IDS=<api-client-id>,<ui-client-id>"
+```
+
+- **Optional email-domain lock (defense in depth).** Set `ALLOWED_EMAIL_DOMAINS`
+  to reject authenticated users outside the org domain with 403:
+
+```bash
+gcloud run services update sshf-api --region us-central1 --project sshf-api-prd \
+  --update-env-vars "ALLOWED_EMAIL_DOMAINS=starsandstripeshonorflight.org"
+```
+
 ## Infrastructure reference (administrators)
 
 One-time setup that the pipeline depends on. If any of this is removed, the
@@ -222,5 +241,7 @@ promotion workflow breaks:
 | Auth step fails with a token/OIDC error | Workload Identity Federation provider, its attribute condition, or the SA binding was changed. Compare against the Infrastructure reference above. |
 | Smoke test fails, traffic unchanged | The new revision does not boot or `/api-docs/` errors. Check revision logs in the prod project; production users are unaffected. Fix and release again. |
 | Users authenticate but have no roles | Admin SDK API disabled in the project, runtime SA missing the Workspace Groups Reader role, or a cached token (30-minute cache — re-sign-in). |
+| Every authenticated request returns 401 after a deploy | The token audience no longer matches. `GOOGLE_CLIENT_ID` on the service must equal the OAuth client the UI/Swagger mint tokens with; if the UI uses a different client, add it to `ALLOWED_CLIENT_IDS`. |
+| Some users get 403 | `ALLOWED_EMAIL_DOMAINS` is set and their verified email is outside it (or email scope/verification is missing). |
 | New secret value not taking effect | Revisions pin secret versions at deploy time. Force a new revision (see Configuration and secrets). |
 | CORS errors from the UI | The UI origin is missing from the service's `ALLOWED_ORIGINS` env var. |

--- a/env.example
+++ b/env.example
@@ -9,5 +9,18 @@ ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8080,https://sshf-ui-5939
 # Public API base URL used in OpenAPI/Swagger server list (defaults to http://localhost:8080)
 API_URL=http://localhost:8080
 
-# Google OAuth client ID for Swagger UI authentication
+# Google OAuth client ID for Swagger UI authentication.
+# Also used to validate incoming access tokens: a token is rejected unless it
+# was issued for this client ID (its `aud`). This is the primary API auth gate.
 GOOGLE_CLIENT_ID=your_google_client_id_here
+
+# Optional. Comma-separated OAuth client IDs whose access tokens are accepted.
+# Overrides GOOGLE_CLIENT_ID for audience validation when multiple clients
+# (e.g. a separate UI client) must be allowed. Leave unset to accept only
+# GOOGLE_CLIENT_ID.
+# ALLOWED_CLIENT_IDS=
+
+# Optional defense-in-depth. Comma-separated email domains permitted to access
+# the API. When set, authenticated users whose verified email is outside these
+# domains receive 403. Leave unset to rely solely on audience validation.
+# ALLOWED_EMAIL_DOMAINS=starsandstripeshonorflight.org

--- a/index.js
+++ b/index.js
@@ -2,10 +2,12 @@ import 'dotenv/config';
 import express from 'express';
 import cors from 'cors';
 import { google } from 'googleapis';
+import { OAuth2Client } from 'google-auth-library';
 import { specs } from './swagger/swagger.js';
 import { swaggerUiServe, swaggerUiSetup } from './swagger/swagger-ui.js';
 import { dbSession } from './utils/db.js';
 import { buildCorsOptions } from './utils/cors.js';
+import { assertValidTokenClaims, TokenAudienceError } from './utils/auth.js';
 
 // Import route handlers
 import { getMessage, postMessage } from './routes/msg.js';
@@ -67,6 +69,9 @@ app.use(cors(buildCorsOptions()));
 // In-memory cache for user authentication
 const userCache = new Map();
 const userCacheTTL = 30 * 60 * 1000; // 30 minutes in milliseconds
+
+// Client used only to introspect incoming access tokens (validate audience)
+const tokenInfoClient = new OAuth2Client();
 
 // Route definitions
 app.get('/secure-data', authenticate, getSecureData);
@@ -248,6 +253,35 @@ async function authenticate(req, res, next) {
                 // Remove expired cache entry
                 userCache.delete(token);
             }
+        }
+
+        // Introspect the token so we can confirm it was actually issued for
+        // this application's OAuth client. A valid Google token alone is not
+        // enough: without this check any Google access token from any client
+        // would be accepted.
+        let tokenInfo;
+        try {
+            tokenInfo = await tokenInfoClient.getTokenInfo(token);
+        } catch (introspectionError) {
+            const status = introspectionError?.status ?? introspectionError?.response?.status;
+            if (status && status >= 400 && status < 500) {
+                return res.status(401).json({ message: 'Unauthorized: Invalid token' });
+            }
+            console.error('Token introspection failed:', introspectionError?.message);
+            return res.status(503).json({ message: 'Authentication service unavailable' });
+        }
+
+        try {
+            assertValidTokenClaims({
+                aud: tokenInfo.aud,
+                email: tokenInfo.email,
+                emailVerified: tokenInfo.email_verified
+            });
+        } catch (validationError) {
+            if (validationError instanceof TokenAudienceError) {
+                return res.status(401).json({ message: 'Unauthorized: Token not issued for this application' });
+            }
+            return res.status(403).json({ message: 'Forbidden: Account not permitted' });
         }
 
         // Fetch basic user info

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sshf-api",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/swagger/swagger.js
+++ b/swagger/swagger.js
@@ -65,7 +65,7 @@ const definition = {
   openapi: '3.0.0',
   info: {
     title: 'SSHF API',
-    version: '1.0.1',
+    version: '1.0.2',
     description: 'API for managing veterans documents with Google authentication',
   },
   servers: getServers(),
@@ -73,6 +73,11 @@ const definition = {
     securitySchemes: {
       GoogleAuth: {
         type: 'oauth2',
+        description:
+          'Google OAuth2. The access token must be issued for this API\'s ' +
+          'configured OAuth client; tokens from other clients are rejected ' +
+          'with 401. Protected endpoints return 401 for a missing, invalid, ' +
+          'or wrong-audience token and 403 when the account is not permitted.',
         flows: {
           implicit: {
             authorizationUrl: 'https://accounts.google.com/o/oauth2/v2/auth',

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -1,0 +1,148 @@
+import { expect } from 'chai';
+import {
+    getAllowedClientIds,
+    getAllowedEmailDomains,
+    assertValidTokenClaims,
+    TokenAudienceError,
+    DomainNotAllowedError
+} from '../utils/auth.js';
+
+const OUR_CLIENT_ID = '111111111111-ourapp.apps.googleusercontent.com';
+const OTHER_CLIENT_ID = '764086051850-6qr4p6gpi6hn506pt8ejuq83di341hur.apps.googleusercontent.com'; // e.g. gcloud
+
+describe('Auth token validation utilities', () => {
+    const originalClientId = process.env.GOOGLE_CLIENT_ID;
+    const originalAllowedClientIds = process.env.ALLOWED_CLIENT_IDS;
+    const originalAllowedDomains = process.env.ALLOWED_EMAIL_DOMAINS;
+
+    const restore = (key, value) => {
+        if (value === undefined) {
+            delete process.env[key];
+        } else {
+            process.env[key] = value;
+        }
+    };
+
+    afterEach(() => {
+        restore('GOOGLE_CLIENT_ID', originalClientId);
+        restore('ALLOWED_CLIENT_IDS', originalAllowedClientIds);
+        restore('ALLOWED_EMAIL_DOMAINS', originalAllowedDomains);
+    });
+
+    describe('getAllowedClientIds', () => {
+        it('returns an empty list when nothing is configured', () => {
+            delete process.env.GOOGLE_CLIENT_ID;
+            delete process.env.ALLOWED_CLIENT_IDS;
+            expect(getAllowedClientIds()).to.deep.equal([]);
+        });
+
+        it('falls back to GOOGLE_CLIENT_ID when ALLOWED_CLIENT_IDS is unset', () => {
+            process.env.GOOGLE_CLIENT_ID = OUR_CLIENT_ID;
+            delete process.env.ALLOWED_CLIENT_IDS;
+            expect(getAllowedClientIds()).to.deep.equal([OUR_CLIENT_ID]);
+        });
+
+        it('prefers ALLOWED_CLIENT_IDS and parses a comma-separated list', () => {
+            process.env.GOOGLE_CLIENT_ID = OUR_CLIENT_ID;
+            process.env.ALLOWED_CLIENT_IDS = ` ${OUR_CLIENT_ID} , ${OTHER_CLIENT_ID} ,`;
+            expect(getAllowedClientIds()).to.deep.equal([OUR_CLIENT_ID, OTHER_CLIENT_ID]);
+        });
+    });
+
+    describe('getAllowedEmailDomains', () => {
+        it('returns an empty list when ALLOWED_EMAIL_DOMAINS is unset', () => {
+            delete process.env.ALLOWED_EMAIL_DOMAINS;
+            expect(getAllowedEmailDomains()).to.deep.equal([]);
+        });
+
+        it('parses, trims, and lowercases a comma-separated list', () => {
+            process.env.ALLOWED_EMAIL_DOMAINS = ' Example.ORG , Foo.com ';
+            expect(getAllowedEmailDomains()).to.deep.equal(['example.org', 'foo.com']);
+        });
+    });
+
+    describe('assertValidTokenClaims - audience', () => {
+        const options = { allowedClientIds: [OUR_CLIENT_ID] };
+
+        it('passes when aud matches an allowed client id', () => {
+            expect(() => assertValidTokenClaims({ aud: OUR_CLIENT_ID }, options)).to.not.throw();
+        });
+
+        it('throws TokenAudienceError when aud belongs to a different client (the exploit case)', () => {
+            expect(() => assertValidTokenClaims({ aud: OTHER_CLIENT_ID }, options))
+                .to.throw(TokenAudienceError);
+        });
+
+        it('throws TokenAudienceError when aud is missing', () => {
+            expect(() => assertValidTokenClaims({ aud: undefined }, options))
+                .to.throw(TokenAudienceError);
+        });
+
+        it('throws TokenAudienceError when no client ids are configured', () => {
+            expect(() => assertValidTokenClaims({ aud: OUR_CLIENT_ID }, { allowedClientIds: [] }))
+                .to.throw(TokenAudienceError);
+        });
+
+        it('reads allowed client ids from the environment when options are omitted', () => {
+            process.env.GOOGLE_CLIENT_ID = OUR_CLIENT_ID;
+            delete process.env.ALLOWED_CLIENT_IDS;
+            delete process.env.ALLOWED_EMAIL_DOMAINS;
+            expect(() => assertValidTokenClaims({ aud: OUR_CLIENT_ID })).to.not.throw();
+            expect(() => assertValidTokenClaims({ aud: OTHER_CLIENT_ID })).to.throw(TokenAudienceError);
+        });
+    });
+
+    describe('assertValidTokenClaims - email domain (opt-in)', () => {
+        const base = { allowedClientIds: [OUR_CLIENT_ID], allowedEmailDomains: ['starsandstripeshonorflight.org'] };
+
+        it('does not check the domain when no domains are configured', () => {
+            const options = { allowedClientIds: [OUR_CLIENT_ID], allowedEmailDomains: [] };
+            expect(() => assertValidTokenClaims(
+                { aud: OUR_CLIENT_ID, email: 'stranger@gmail.com', emailVerified: true },
+                options
+            )).to.not.throw();
+        });
+
+        it('passes for an allowed, verified domain (boolean true)', () => {
+            expect(() => assertValidTokenClaims(
+                { aud: OUR_CLIENT_ID, email: 'steve@starsandstripeshonorflight.org', emailVerified: true },
+                base
+            )).to.not.throw();
+        });
+
+        it('passes when email_verified arrives as the string "true"', () => {
+            expect(() => assertValidTokenClaims(
+                { aud: OUR_CLIENT_ID, email: 'steve@STARSANDSTRIPESHONORFLIGHT.org', emailVerified: 'true' },
+                base
+            )).to.not.throw();
+        });
+
+        it('throws DomainNotAllowedError for a disallowed domain', () => {
+            expect(() => assertValidTokenClaims(
+                { aud: OUR_CLIENT_ID, email: 'attacker@gmail.com', emailVerified: true },
+                base
+            )).to.throw(DomainNotAllowedError);
+        });
+
+        it('throws DomainNotAllowedError when the email is unverified', () => {
+            expect(() => assertValidTokenClaims(
+                { aud: OUR_CLIENT_ID, email: 'steve@starsandstripeshonorflight.org', emailVerified: false },
+                base
+            )).to.throw(DomainNotAllowedError);
+        });
+
+        it('throws DomainNotAllowedError when the email is missing', () => {
+            expect(() => assertValidTokenClaims(
+                { aud: OUR_CLIENT_ID, emailVerified: true },
+                base
+            )).to.throw(DomainNotAllowedError);
+        });
+
+        it('checks audience before domain', () => {
+            expect(() => assertValidTokenClaims(
+                { aud: OTHER_CLIENT_ID, email: 'steve@starsandstripeshonorflight.org', emailVerified: true },
+                base
+            )).to.throw(TokenAudienceError);
+        });
+    });
+});

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -1,0 +1,92 @@
+/**
+ * Access-token authorization helpers.
+ *
+ * The API receives an opaque Google OAuth2 access token as a Bearer token.
+ * A valid Google token is not sufficient: it must have been issued for THIS
+ * application's OAuth client. Optionally, an allow-list of email domains 
+ * provides defense in depth on top of the OAuth client's org-internal consent restriction.
+ */
+
+/** Token was not issued for one of this application's OAuth clients. */
+export class TokenAudienceError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = 'TokenAudienceError';
+    }
+}
+
+/** Token is valid and for this app, but the account is not permitted. */
+export class DomainNotAllowedError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = 'DomainNotAllowedError';
+    }
+}
+
+function parseList(raw) {
+    if (!raw || raw.trim() === '') {
+        return [];
+    }
+    return raw
+        .split(',')
+        .map((entry) => entry.trim())
+        .filter((entry) => entry.length > 0);
+}
+
+/**
+ * OAuth client IDs whose tokens this API accepts. Prefers ALLOWED_CLIENT_IDS
+ * (comma-separated) and falls back to the single GOOGLE_CLIENT_ID.
+ */
+export function getAllowedClientIds(env = process.env) {
+    const explicit = env.ALLOWED_CLIENT_IDS;
+    if (explicit && explicit.trim() !== '') {
+        return parseList(explicit);
+    }
+    return parseList(env.GOOGLE_CLIENT_ID);
+}
+
+/**
+ * Email domains permitted to access the API. Empty (the default) disables the
+ * domain check, leaving audience validation as the sole gate.
+ */
+export function getAllowedEmailDomains(env = process.env) {
+    return parseList(env.ALLOWED_EMAIL_DOMAINS).map((domain) => domain.toLowerCase());
+}
+
+function isEmailVerified(value) {
+    // Google's tokeninfo response may deliver this as a boolean or the
+    // string "true"; treat both as verified.
+    return value === true || value === 'true';
+}
+
+/**
+ * Validate the security-relevant claims of an introspected access token.
+ *
+ * @param {{aud?: string, email?: string, emailVerified?: boolean|string}} claims
+ * @param {{allowedClientIds?: string[], allowedEmailDomains?: string[]}} [options]
+ * @throws {TokenAudienceError} when the token was not issued for this app
+ * @throws {DomainNotAllowedError} when the account email is not permitted
+ */
+export function assertValidTokenClaims(claims = {}, options = {}) {
+    const allowedClientIds = options.allowedClientIds ?? getAllowedClientIds();
+    const allowedEmailDomains = options.allowedEmailDomains ?? getAllowedEmailDomains();
+
+    if (allowedClientIds.length === 0) {
+        throw new TokenAudienceError('No allowed OAuth client IDs are configured');
+    }
+
+    if (!claims.aud || !allowedClientIds.includes(claims.aud)) {
+        throw new TokenAudienceError('Access token was not issued for this application');
+    }
+
+    if (allowedEmailDomains.length > 0) {
+        const email = typeof claims.email === 'string' ? claims.email.toLowerCase() : '';
+        if (!email || !isEmailVerified(claims.emailVerified)) {
+            throw new DomainNotAllowedError('A verified account email is required');
+        }
+        const domain = email.split('@')[1];
+        if (!domain || !allowedEmailDomains.includes(domain)) {
+            throw new DomainNotAllowedError('Account email domain is not permitted');
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Close an auth gap where the API accepted **any** valid access token regardless of which OAuth client issued it 
- `authenticate` now introspects each token via `google-auth-library` `getTokenInfo()` and rejects it unless its `aud` matches the app's OAuth client (`GOOGLE_CLIENT_ID`, or `ALLOWED_CLIENT_IDS`). Verified the UI and Swagger share the same client ID, so no service config change is required.
- Optional `ALLOWED_EMAIL_DOMAINS` adds a defense-in-depth 403 for out-of-domain accounts.
- New tested `utils/auth.js` (17 tests incl. the exploit case); docs updated (README auth section, `env.example`, Swagger security scheme, `docs/DEPLOYMENT.md`).

## Response semantics
- 401: missing / invalid / expired / wrong-audience token
- 403: valid token but account not permitted (only when `ALLOWED_EMAIL_DOMAINS` set)
- 503: token introspection temporarily unavailable

## Test plan
- [x] `npm test` passes (936 passing; +17 new)
- [x] New tests fail without the module, pass after (test-first)
- [x] After merge: verify a real UI/Swagger login still works in dev
- [x] Confirm a token from a different OAuth client is now rejected with 401

## Follow-ups (noted, out of scope here)
- Per-route group authorization (give `ROLE_FULL_ACCESS`/`ROLE_READ_ACCESS` real meaning; requires those env vars in prod).
- Consider migrating the UI to send a verifiable Google **ID token** for offline audience validation.