### PR TITLE
Enforce Workspace group membership on data routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Required environment variables:
 | `GOOGLE_CLIENT_ID` | Google OAuth client ID for Swagger UI auth, and the client whose access tokens the API accepts (audience validation) |
 | `ALLOWED_CLIENT_IDS` | Optional. Comma-separated OAuth client IDs accepted for token audience validation (overrides `GOOGLE_CLIENT_ID` when set) |
 | `ALLOWED_EMAIL_DOMAINS` | Optional. Comma-separated email domains permitted to access the API; unset disables the domain check |
+| `ALLOWED_GROUP_EMAILS` | Optional. Comma-separated Workspace group emails required for data routes; unset disables the group gate. Dev: `sshf_app_dev_full_access@…`; prod: `sshf_app_prd_full_access@…` |
 | `GOOGLE_SERVICE_ACCOUNT_EMAIL` | Service account email (local dev) |
 | `GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY` | Service account private key (local dev) |
 
@@ -109,7 +110,7 @@ See the [CI/CD and Deployment Guide](docs/DEPLOYMENT.md) for the full process: r
 ## Authentication & Authorization
 
 Protected endpoints require a Google OAuth2 access token as a Bearer token.
-The API enforces two checks before a request proceeds:
+The API enforces these checks before a request proceeds:
 
 1. **Audience validation** — the token is introspected and rejected with `401`
    unless it was issued for this API's OAuth client (`GOOGLE_CLIENT_ID`, or any
@@ -118,11 +119,15 @@ The API enforces two checks before a request proceeds:
 2. **Email domain (optional)** — when `ALLOWED_EMAIL_DOMAINS` is set, an
    authenticated user whose verified email falls outside those domains receives
    `403`.
+3. **Workspace group membership (optional, required in deployed envs)** — when
+   `ALLOWED_GROUP_EMAILS` is set, data routes require membership in at least
+   one listed group (`403` otherwise, including when Admin SDK returns no
+   roles). `GET /user/hasgroup` stays auth-only so the UI can probe membership
+   during sign-in.
 
-Group memberships are attached to the request for endpoints that report them
-(e.g. `GET /user/hasgroup`). Responses: `401` for a missing, invalid, expired,
-or wrong-audience token; `403` for a permitted-token account that is not
-allowed; `503` if token introspection is temporarily unavailable.
+Responses: `401` for a missing, invalid, expired, or wrong-audience token;
+`403` for a permitted-token account that is not allowed (domain or group);
+`503` if token introspection is temporarily unavailable.
 
 ## API Documentation
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -207,6 +207,22 @@ gcloud run services update sshf-api --region us-central1 --project sshf-api-prd 
   --update-env-vars "ALLOWED_EMAIL_DOMAINS=starsandstripeshonorflight.org"
 ```
 
+- **Workspace group membership (required for deployed envs).** Set
+  `ALLOWED_GROUP_EMAILS` so data routes reject authenticated users who are not
+  in the environment full-access group. Without this env var the group check
+  is disabled. Set it in the same release window as the authorize middleware
+  ships. `GET /user/hasgroup` remains auth-only for UI login probes.
+
+```bash
+# Dev
+gcloud run services update sshf-api --region us-central1 --project sshf-api-dev \
+  --update-env-vars "ALLOWED_GROUP_EMAILS=sshf_app_dev_full_access@starsandstripeshonorflight.org"
+
+# Prod
+gcloud run services update sshf-api --region us-central1 --project sshf-api-prd \
+  --update-env-vars "ALLOWED_GROUP_EMAILS=sshf_app_prd_full_access@starsandstripeshonorflight.org"
+```
+
 ## Infrastructure reference (administrators)
 
 One-time setup that the pipeline depends on. If any of this is removed, the
@@ -240,8 +256,8 @@ promotion workflow breaks:
 | Promote never asks for approval | The `production` GitHub environment or its required reviewer is missing. |
 | Auth step fails with a token/OIDC error | Workload Identity Federation provider, its attribute condition, or the SA binding was changed. Compare against the Infrastructure reference above. |
 | Smoke test fails, traffic unchanged | The new revision does not boot or `/api-docs/` errors. Check revision logs in the prod project; production users are unaffected. Fix and release again. |
-| Users authenticate but have no roles | Admin SDK API disabled in the project, runtime SA missing the Workspace Groups Reader role, or a cached token (30-minute cache — re-sign-in). |
+| Users authenticate but have no roles | Admin SDK API disabled in the project, runtime SA missing the Workspace Groups Reader role, or a cached token (30-minute cache — re-sign-in). With `ALLOWED_GROUP_EMAILS` set this becomes data-route `403` (fail closed). |
 | Every authenticated request returns 401 after a deploy | The token audience no longer matches. `GOOGLE_CLIENT_ID` on the service must equal the OAuth client the UI/Swagger mint tokens with; if the UI uses a different client, add it to `ALLOWED_CLIENT_IDS`. |
-| Some users get 403 | `ALLOWED_EMAIL_DOMAINS` is set and their verified email is outside it (or email scope/verification is missing). |
+| Some users get 403 | `ALLOWED_EMAIL_DOMAINS` rejects their verified email, or `ALLOWED_GROUP_EMAILS` is set and they are not in a listed Workspace group (or Admin SDK returned no roles). |
 | New secret value not taking effect | Revisions pin secret versions at deploy time. Force a new revision (see Configuration and secrets). |
 | CORS errors from the UI | The UI origin is missing from the service's `ALLOWED_ORIGINS` env var. |

--- a/env.example
+++ b/env.example
@@ -24,3 +24,12 @@ GOOGLE_CLIENT_ID=your_google_client_id_here
 # the API. When set, authenticated users whose verified email is outside these
 # domains receive 403. Leave unset to rely solely on audience validation.
 # ALLOWED_EMAIL_DOMAINS=starsandstripeshonorflight.org
+
+# Workspace group emails permitted to call data routes (comma-separated).
+# When set, authenticate still loads groups, but authorize rejects users who
+# are not members with 403 (fail closed if Admin SDK returns no roles).
+# GET /user/hasgroup stays auth-only so the UI can probe membership.
+# Dev:  sshf_app_dev_full_access@starsandstripeshonorflight.org
+# Prod: sshf_app_prd_full_access@starsandstripeshonorflight.org
+# Leave unset locally to disable the group gate.
+# ALLOWED_GROUP_EMAILS=sshf_app_dev_full_access@starsandstripeshonorflight.org

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ import { specs } from './swagger/swagger.js';
 import { swaggerUiServe, swaggerUiSetup } from './swagger/swagger-ui.js';
 import { dbSession } from './utils/db.js';
 import { buildCorsOptions } from './utils/cors.js';
-import { assertValidTokenClaims, TokenAudienceError } from './utils/auth.js';
+import { assertValidTokenClaims, TokenAudienceError, authorize } from './utils/auth.js';
 
 // Import route handlers
 import { getMessage, postMessage } from './routes/msg.js';
@@ -74,80 +74,80 @@ const userCacheTTL = 30 * 60 * 1000; // 30 minutes in milliseconds
 const tokenInfoClient = new OAuth2Client();
 
 // Route definitions
-app.get('/secure-data', authenticate, getSecureData);
+app.get('/secure-data', authenticate, authorize, getSecureData);
 app.get('/user/hasgroup', authenticate, getHasGroup);
 app.get("/msg", getMessage);
-app.get("/search", authenticate, dbSession, getSearch);
+app.get("/search", authenticate, authorize, dbSession, getSearch);
 app.use(express.json()); // for parsing application/json
 app.post("/msg", postMessage);
 
 // Generic document routes
-app.post("/docs", authenticate, dbSession, createDocument);
-app.get("/docs/:id", authenticate, dbSession, retrieveDocument);
-app.put("/docs/:id", authenticate, dbSession, updateDocument);
-app.delete("/docs/:id", authenticate, dbSession, deleteDocument);
+app.post("/docs", authenticate, authorize, dbSession, createDocument);
+app.get("/docs/:id", authenticate, authorize, dbSession, retrieveDocument);
+app.put("/docs/:id", authenticate, authorize, dbSession, updateDocument);
+app.delete("/docs/:id", authenticate, authorize, dbSession, deleteDocument);
 
 // Veteran-specific routes
-app.post("/veterans", authenticate, dbSession, createVeteran);
-app.get("/veterans/search", authenticate, dbSession, searchUnpairedVeterans);
-app.get("/veterans/:id", authenticate, dbSession, retrieveVeteran);
-app.put("/veterans/:id", authenticate, dbSession, updateVeteran);
-app.patch("/veterans/:id/seat", authenticate, dbSession, updateVeteranSeat);
-app.patch("/veterans/:id/bus", authenticate, dbSession, updateVeteranBus);
-app.patch("/veterans/:id/mail-call-received", authenticate, dbSession, updateVeteranMailCallReceived);
-app.patch("/veterans/:id/mail-call-adopt", authenticate, dbSession, updateVeteranMailCallAdopt);
-app.patch("/veterans/:id/medical-form", authenticate, dbSession, updateVeteranMedicalForm);
-app.patch("/veterans/:id/medical-review", authenticate, dbSession, updateVeteranMedicalReview);
-app.patch("/veterans/:id/vaccinated", authenticate, dbSession, updateVeteranVaccinated);
-app.patch("/veterans/:id/homecoming-destination", authenticate, dbSession, updateVeteranHomecomingDestination);
-app.patch("/veterans/:id/apparel-shirt-size", authenticate, dbSession, updateVeteranApparelShirtSize);
-app.patch("/veterans/:id/apparel-jacket-size", authenticate, dbSession, updateVeteranApparelJacketSize);
-app.patch("/veterans/:id/apparel-notes", authenticate, dbSession, updateVeteranApparelNotes);
-app.delete("/veterans/:id", authenticate, dbSession, deleteVeteran);
+app.post("/veterans", authenticate, authorize, dbSession, createVeteran);
+app.get("/veterans/search", authenticate, authorize, dbSession, searchUnpairedVeterans);
+app.get("/veterans/:id", authenticate, authorize, dbSession, retrieveVeteran);
+app.put("/veterans/:id", authenticate, authorize, dbSession, updateVeteran);
+app.patch("/veterans/:id/seat", authenticate, authorize, dbSession, updateVeteranSeat);
+app.patch("/veterans/:id/bus", authenticate, authorize, dbSession, updateVeteranBus);
+app.patch("/veterans/:id/mail-call-received", authenticate, authorize, dbSession, updateVeteranMailCallReceived);
+app.patch("/veterans/:id/mail-call-adopt", authenticate, authorize, dbSession, updateVeteranMailCallAdopt);
+app.patch("/veterans/:id/medical-form", authenticate, authorize, dbSession, updateVeteranMedicalForm);
+app.patch("/veterans/:id/medical-review", authenticate, authorize, dbSession, updateVeteranMedicalReview);
+app.patch("/veterans/:id/vaccinated", authenticate, authorize, dbSession, updateVeteranVaccinated);
+app.patch("/veterans/:id/homecoming-destination", authenticate, authorize, dbSession, updateVeteranHomecomingDestination);
+app.patch("/veterans/:id/apparel-shirt-size", authenticate, authorize, dbSession, updateVeteranApparelShirtSize);
+app.patch("/veterans/:id/apparel-jacket-size", authenticate, authorize, dbSession, updateVeteranApparelJacketSize);
+app.patch("/veterans/:id/apparel-notes", authenticate, authorize, dbSession, updateVeteranApparelNotes);
+app.delete("/veterans/:id", authenticate, authorize, dbSession, deleteVeteran);
 
 // Guardian-specific routes
-app.post("/guardians", authenticate, dbSession, createGuardian);
-app.get("/guardians/:id", authenticate, dbSession, retrieveGuardian);
-app.put("/guardians/:id", authenticate, dbSession, updateGuardian);
-app.patch("/guardians/:id/seat", authenticate, dbSession, updateGuardianSeat);
-app.patch("/guardians/:id/bus", authenticate, dbSession, updateGuardianBus);
-app.patch("/guardians/:id/training-notes", authenticate, dbSession, updateGuardianTrainingNotes);
-app.patch("/guardians/:id/training-complete", authenticate, dbSession, updateGuardianTrainingComplete);
-app.patch("/guardians/:id/waiver", authenticate, dbSession, updateGuardianWaiver);
-app.patch("/guardians/:id/training-see-doc", authenticate, dbSession, updateGuardianTrainingSeeDoc);
-app.patch("/guardians/:id/vaccinated", authenticate, dbSession, updateGuardianVaccinated);
-app.patch("/guardians/:id/medical-form", authenticate, dbSession, updateGuardianMedicalForm);
-app.patch("/guardians/:id/paid", authenticate, dbSession, updateGuardianPaid);
-app.patch("/guardians/:id/books-ordered", authenticate, dbSession, updateGuardianBooksOrdered);
-app.patch("/guardians/:id/apparel-shirt-size", authenticate, dbSession, updateGuardianApparelShirtSize);
-app.patch("/guardians/:id/apparel-jacket-size", authenticate, dbSession, updateGuardianApparelJacketSize);
-app.patch("/guardians/:id/apparel-notes", authenticate, dbSession, updateGuardianApparelNotes);
-app.delete("/guardians/:id", authenticate, dbSession, deleteGuardian);
+app.post("/guardians", authenticate, authorize, dbSession, createGuardian);
+app.get("/guardians/:id", authenticate, authorize, dbSession, retrieveGuardian);
+app.put("/guardians/:id", authenticate, authorize, dbSession, updateGuardian);
+app.patch("/guardians/:id/seat", authenticate, authorize, dbSession, updateGuardianSeat);
+app.patch("/guardians/:id/bus", authenticate, authorize, dbSession, updateGuardianBus);
+app.patch("/guardians/:id/training-notes", authenticate, authorize, dbSession, updateGuardianTrainingNotes);
+app.patch("/guardians/:id/training-complete", authenticate, authorize, dbSession, updateGuardianTrainingComplete);
+app.patch("/guardians/:id/waiver", authenticate, authorize, dbSession, updateGuardianWaiver);
+app.patch("/guardians/:id/training-see-doc", authenticate, authorize, dbSession, updateGuardianTrainingSeeDoc);
+app.patch("/guardians/:id/vaccinated", authenticate, authorize, dbSession, updateGuardianVaccinated);
+app.patch("/guardians/:id/medical-form", authenticate, authorize, dbSession, updateGuardianMedicalForm);
+app.patch("/guardians/:id/paid", authenticate, authorize, dbSession, updateGuardianPaid);
+app.patch("/guardians/:id/books-ordered", authenticate, authorize, dbSession, updateGuardianBooksOrdered);
+app.patch("/guardians/:id/apparel-shirt-size", authenticate, authorize, dbSession, updateGuardianApparelShirtSize);
+app.patch("/guardians/:id/apparel-jacket-size", authenticate, authorize, dbSession, updateGuardianApparelJacketSize);
+app.patch("/guardians/:id/apparel-notes", authenticate, authorize, dbSession, updateGuardianApparelNotes);
+app.delete("/guardians/:id", authenticate, authorize, dbSession, deleteGuardian);
 
 // Flight-specific routes
-app.get("/flights", authenticate, dbSession, listFlights);
-app.post("/flights", authenticate, dbSession, createFlight);
-app.get("/flights/:id", authenticate, dbSession, retrieveFlight);
-app.put("/flights/:id", authenticate, dbSession, updateFlight);
+app.get("/flights", authenticate, authorize, dbSession, listFlights);
+app.post("/flights", authenticate, authorize, dbSession, createFlight);
+app.get("/flights/:id", authenticate, authorize, dbSession, retrieveFlight);
+app.put("/flights/:id", authenticate, authorize, dbSession, updateFlight);
 
 // Flight assignment routes
-app.get("/flights/:id/assignments", authenticate, dbSession, getFlightAssignments);
-app.post("/flights/:id/assignments", authenticate, dbSession, addVeteransToFlight);
+app.get("/flights/:id/assignments", authenticate, authorize, dbSession, getFlightAssignments);
+app.post("/flights/:id/assignments", authenticate, authorize, dbSession, addVeteransToFlight);
 
 // Flight detail routes
-app.get("/flights/:id/detail", authenticate, dbSession, getFlightDetail);
+app.get("/flights/:id/detail", authenticate, authorize, dbSession, getFlightDetail);
 
 // Waitlist routes
-app.get("/waitlist", authenticate, dbSession, getWaitlist);
-app.get("/waitlist/veteran-groups", authenticate, dbSession, getWaitlistVeteranGroups);
+app.get("/waitlist", authenticate, authorize, dbSession, getWaitlist);
+app.get("/waitlist/veteran-groups", authenticate, authorize, dbSession, getWaitlistVeteranGroups);
 
 // Recent Activity routes
-app.get("/recent-activity", authenticate, dbSession, getRecentActivity);
+app.get("/recent-activity", authenticate, authorize, dbSession, getRecentActivity);
 
 // Export routes
-app.get("/exports/flight", authenticate, dbSession, exportFlightCsv);
-app.get("/exports/callcenterfollowup", authenticate, dbSession, exportCallCenterFollowUpCsv);
-app.get("/exports/tourlead", authenticate, dbSession, exportTourLeadCsv);
+app.get("/exports/flight", authenticate, authorize, dbSession, exportFlightCsv);
+app.get("/exports/callcenterfollowup", authenticate, authorize, dbSession, exportCallCenterFollowUpCsv);
+app.get("/exports/tourlead", authenticate, authorize, dbSession, exportTourLeadCsv);
 
 // Expose OpenAPI spec at custom endpoint
 app.get('/openapi.json', (req, res) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sshf-api",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/routes/user.js
+++ b/routes/user.js
@@ -1,6 +1,43 @@
+/**
+ * @swagger
+ * /user/hasgroup:
+ *   get:
+ *     summary: Check whether the authenticated user belongs to a Workspace group
+ *     description: >
+ *       Auth-only probe used by the UI during sign-in. Does not require
+ *       membership in ALLOWED_GROUP_EMAILS so non-members can still discover
+ *       that they are unauthorized. Data routes enforce group membership
+ *       separately via the authorize middleware.
+ *     tags: [User]
+ *     security:
+ *       - GoogleAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: groupEmail
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: email
+ *         description: Workspace group email to check
+ *     responses:
+ *       200:
+ *         description: Membership result for the requested group
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               required: [hasgroup]
+ *               properties:
+ *                 hasgroup:
+ *                   type: boolean
+ *       401:
+ *         description: Missing, invalid, or wrong-audience token
+ *       503:
+ *         description: Token introspection temporarily unavailable
+ */
 export function getHasGroup(req, res) {
     const roles = req.user?.roles;
     const groupEmail = req.query.groupEmail;
     const hasGroup = roles?.some(role => role.email === groupEmail) ?? false;
     res.json({ hasgroup: hasGroup });
-} 
+}

--- a/swagger/swagger.js
+++ b/swagger/swagger.js
@@ -65,7 +65,7 @@ const definition = {
   openapi: '3.0.0',
   info: {
     title: 'SSHF API',
-    version: '1.0.2',
+    version: '1.0.3',
     description: 'API for managing veterans documents with Google authentication',
   },
   servers: getServers(),
@@ -76,8 +76,11 @@ const definition = {
         description:
           'Google OAuth2. The access token must be issued for this API\'s ' +
           'configured OAuth client; tokens from other clients are rejected ' +
-          'with 401. Protected endpoints return 401 for a missing, invalid, ' +
-          'or wrong-audience token and 403 when the account is not permitted.',
+          'with 401. Protected data endpoints return 401 for a missing, ' +
+          'invalid, or wrong-audience token and 403 when the account email ' +
+          'domain or Workspace group membership is not permitted ' +
+          '(ALLOWED_EMAIL_DOMAINS / ALLOWED_GROUP_EMAILS). ' +
+          'GET /user/hasgroup is auth-only so clients can probe group membership.',
         flows: {
           implicit: {
             authorizationUrl: 'https://accounts.google.com/o/oauth2/v2/auth',

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -2,18 +2,25 @@ import { expect } from 'chai';
 import {
     getAllowedClientIds,
     getAllowedEmailDomains,
+    getAllowedGroupEmails,
     assertValidTokenClaims,
+    assertUserInAllowedGroups,
+    authorize,
     TokenAudienceError,
-    DomainNotAllowedError
+    DomainNotAllowedError,
+    GroupNotAllowedError
 } from '../utils/auth.js';
 
 const OUR_CLIENT_ID = '111111111111-ourapp.apps.googleusercontent.com';
 const OTHER_CLIENT_ID = '764086051850-6qr4p6gpi6hn506pt8ejuq83di341hur.apps.googleusercontent.com'; // e.g. gcloud
+const FULL_ACCESS_GROUP = 'sshf_app_dev_full_access@starsandstripeshonorflight.org';
+const OTHER_GROUP = 'some-other-group@starsandstripeshonorflight.org';
 
 describe('Auth token validation utilities', () => {
     const originalClientId = process.env.GOOGLE_CLIENT_ID;
     const originalAllowedClientIds = process.env.ALLOWED_CLIENT_IDS;
     const originalAllowedDomains = process.env.ALLOWED_EMAIL_DOMAINS;
+    const originalAllowedGroups = process.env.ALLOWED_GROUP_EMAILS;
 
     const restore = (key, value) => {
         if (value === undefined) {
@@ -27,6 +34,7 @@ describe('Auth token validation utilities', () => {
         restore('GOOGLE_CLIENT_ID', originalClientId);
         restore('ALLOWED_CLIENT_IDS', originalAllowedClientIds);
         restore('ALLOWED_EMAIL_DOMAINS', originalAllowedDomains);
+        restore('ALLOWED_GROUP_EMAILS', originalAllowedGroups);
     });
 
     describe('getAllowedClientIds', () => {
@@ -143,6 +151,127 @@ describe('Auth token validation utilities', () => {
                 { aud: OTHER_CLIENT_ID, email: 'steve@starsandstripeshonorflight.org', emailVerified: true },
                 base
             )).to.throw(TokenAudienceError);
+        });
+    });
+
+    describe('getAllowedGroupEmails', () => {
+        it('returns an empty list when ALLOWED_GROUP_EMAILS is unset', () => {
+            delete process.env.ALLOWED_GROUP_EMAILS;
+            expect(getAllowedGroupEmails()).to.deep.equal([]);
+        });
+
+        it('parses, trims, and lowercases a comma-separated list', () => {
+            process.env.ALLOWED_GROUP_EMAILS =
+                ` ${FULL_ACCESS_GROUP.toUpperCase()} , ${OTHER_GROUP} `;
+            expect(getAllowedGroupEmails()).to.deep.equal([
+                FULL_ACCESS_GROUP,
+                OTHER_GROUP
+            ]);
+        });
+    });
+
+    describe('assertUserInAllowedGroups', () => {
+        const memberRoles = [{ email: FULL_ACCESS_GROUP, name: 'Full Access' }];
+        const otherRoles = [{ email: OTHER_GROUP, name: 'Other' }];
+
+        it('does not check groups when the allow-list is empty', () => {
+            expect(() => assertUserInAllowedGroups([], { allowedGroupEmails: [] })).to.not.throw();
+            expect(() => assertUserInAllowedGroups(otherRoles, { allowedGroupEmails: [] })).to.not.throw();
+        });
+
+        it('passes when the user is in an allowed group', () => {
+            expect(() => assertUserInAllowedGroups(memberRoles, {
+                allowedGroupEmails: [FULL_ACCESS_GROUP]
+            })).to.not.throw();
+        });
+
+        it('matches group emails case-insensitively', () => {
+            expect(() => assertUserInAllowedGroups(
+                [{ email: FULL_ACCESS_GROUP.toUpperCase() }],
+                { allowedGroupEmails: [FULL_ACCESS_GROUP] }
+            )).to.not.throw();
+        });
+
+        it('throws GroupNotAllowedError when the user is not in an allowed group', () => {
+            expect(() => assertUserInAllowedGroups(otherRoles, {
+                allowedGroupEmails: [FULL_ACCESS_GROUP]
+            })).to.throw(GroupNotAllowedError);
+        });
+
+        it('throws GroupNotAllowedError when roles are empty and groups are configured (fail closed)', () => {
+            expect(() => assertUserInAllowedGroups([], {
+                allowedGroupEmails: [FULL_ACCESS_GROUP]
+            })).to.throw(GroupNotAllowedError);
+        });
+
+        it('throws GroupNotAllowedError when roles are missing and groups are configured', () => {
+            expect(() => assertUserInAllowedGroups(undefined, {
+                allowedGroupEmails: [FULL_ACCESS_GROUP]
+            })).to.throw(GroupNotAllowedError);
+        });
+
+        it('reads allowed groups from the environment when options are omitted', () => {
+            process.env.ALLOWED_GROUP_EMAILS = FULL_ACCESS_GROUP;
+            expect(() => assertUserInAllowedGroups(memberRoles)).to.not.throw();
+            expect(() => assertUserInAllowedGroups(otherRoles)).to.throw(GroupNotAllowedError);
+        });
+    });
+
+    describe('authorize middleware', () => {
+        const createRes = () => {
+            const res = {
+                statusCode: null,
+                body: null,
+                status(code) {
+                    this.statusCode = code;
+                    return this;
+                },
+                json(payload) {
+                    this.body = payload;
+                    return this;
+                }
+            };
+            return res;
+        };
+
+        it('calls next when the user is in an allowed group', () => {
+            process.env.ALLOWED_GROUP_EMAILS = FULL_ACCESS_GROUP;
+            const req = { user: { roles: [{ email: FULL_ACCESS_GROUP }] } };
+            const res = createRes();
+            let nextCalled = false;
+            authorize(req, res, () => { nextCalled = true; });
+            expect(nextCalled).to.equal(true);
+            expect(res.statusCode).to.equal(null);
+        });
+
+        it('returns 403 when the user is not in an allowed group', () => {
+            process.env.ALLOWED_GROUP_EMAILS = FULL_ACCESS_GROUP;
+            const req = { user: { roles: [{ email: OTHER_GROUP }] } };
+            const res = createRes();
+            let nextCalled = false;
+            authorize(req, res, () => { nextCalled = true; });
+            expect(nextCalled).to.equal(false);
+            expect(res.statusCode).to.equal(403);
+            expect(res.body).to.deep.equal({ message: 'Forbidden: Account not permitted' });
+        });
+
+        it('returns 403 when roles are empty and groups are configured', () => {
+            process.env.ALLOWED_GROUP_EMAILS = FULL_ACCESS_GROUP;
+            const req = { user: { roles: [] } };
+            const res = createRes();
+            let nextCalled = false;
+            authorize(req, res, () => { nextCalled = true; });
+            expect(nextCalled).to.equal(false);
+            expect(res.statusCode).to.equal(403);
+        });
+
+        it('calls next when ALLOWED_GROUP_EMAILS is unset', () => {
+            delete process.env.ALLOWED_GROUP_EMAILS;
+            const req = { user: { roles: [] } };
+            const res = createRes();
+            let nextCalled = false;
+            authorize(req, res, () => { nextCalled = true; });
+            expect(nextCalled).to.equal(true);
         });
     });
 });

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -1,0 +1,47 @@
+import { expect } from 'chai';
+import { getHasGroup } from '../routes/user.js';
+
+const FULL_ACCESS_GROUP = 'sshf_app_dev_full_access@starsandstripeshonorflight.org';
+
+describe('getHasGroup', () => {
+    const createRes = () => {
+        const res = {
+            body: null,
+            json(payload) {
+                this.body = payload;
+                return this;
+            }
+        };
+        return res;
+    };
+
+    it('returns hasgroup true when the user is in the requested group', () => {
+        const req = {
+            user: { roles: [{ email: FULL_ACCESS_GROUP }] },
+            query: { groupEmail: FULL_ACCESS_GROUP }
+        };
+        const res = createRes();
+        getHasGroup(req, res);
+        expect(res.body).to.deep.equal({ hasgroup: true });
+    });
+
+    it('returns hasgroup false when the user is not in the requested group', () => {
+        const req = {
+            user: { roles: [{ email: 'other@example.com' }] },
+            query: { groupEmail: FULL_ACCESS_GROUP }
+        };
+        const res = createRes();
+        getHasGroup(req, res);
+        expect(res.body).to.deep.equal({ hasgroup: false });
+    });
+
+    it('returns hasgroup false when the user has no roles (probe still works)', () => {
+        const req = {
+            user: { roles: [] },
+            query: { groupEmail: FULL_ACCESS_GROUP }
+        };
+        const res = createRes();
+        getHasGroup(req, res);
+        expect(res.body).to.deep.equal({ hasgroup: false });
+    });
+});

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -23,6 +23,14 @@ export class DomainNotAllowedError extends Error {
     }
 }
 
+/** Token is valid and for this app, but the user is not in an allowed Workspace group. */
+export class GroupNotAllowedError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = 'GroupNotAllowedError';
+    }
+}
+
 function parseList(raw) {
     if (!raw || raw.trim() === '') {
         return [];
@@ -51,6 +59,15 @@ export function getAllowedClientIds(env = process.env) {
  */
 export function getAllowedEmailDomains(env = process.env) {
     return parseList(env.ALLOWED_EMAIL_DOMAINS).map((domain) => domain.toLowerCase());
+}
+
+/**
+ * Workspace group emails permitted to access protected data routes. Empty
+ * (the default) disables the group check so local development can omit it.
+ * When set, membership is required (fail closed if Admin SDK returns no roles).
+ */
+export function getAllowedGroupEmails(env = process.env) {
+    return parseList(env.ALLOWED_GROUP_EMAILS).map((email) => email.toLowerCase());
 }
 
 function isEmailVerified(value) {
@@ -88,5 +105,46 @@ export function assertValidTokenClaims(claims = {}, options = {}) {
         if (!domain || !allowedEmailDomains.includes(domain)) {
             throw new DomainNotAllowedError('Account email domain is not permitted');
         }
+    }
+}
+
+/**
+ * Require the authenticated user to belong to at least one configured
+ * Workspace group. When the allow-list is empty the check is disabled.
+ *
+ * @param {Array<{email?: string}>|undefined|null} roles
+ * @param {{allowedGroupEmails?: string[]}} [options]
+ * @throws {GroupNotAllowedError} when the user is not in an allowed group
+ */
+export function assertUserInAllowedGroups(roles, options = {}) {
+    const allowedGroupEmails = options.allowedGroupEmails ?? getAllowedGroupEmails();
+
+    if (allowedGroupEmails.length === 0) {
+        return;
+    }
+
+    const userEmails = (Array.isArray(roles) ? roles : [])
+        .map((role) => (typeof role?.email === 'string' ? role.email.toLowerCase() : ''))
+        .filter((email) => email.length > 0);
+
+    const isMember = userEmails.some((email) => allowedGroupEmails.includes(email));
+    if (!isMember) {
+        throw new GroupNotAllowedError('Account is not a member of an allowed group');
+    }
+}
+
+/**
+ * Express middleware: enforce ALLOWED_GROUP_EMAILS against req.user.roles.
+ * Intended to run after authenticate on data routes (not on /user/hasgroup).
+ */
+export function authorize(req, res, next) {
+    try {
+        assertUserInAllowedGroups(req.user?.roles);
+        next();
+    } catch (error) {
+        if (error instanceof GroupNotAllowedError) {
+            return res.status(403).json({ message: 'Forbidden: Account not permitted' });
+        }
+        throw error;
     }
 }


### PR DESCRIPTION
## Summary
- Add `ALLOWED_GROUP_EMAILS` and an `authorize` middleware that requires Workspace group membership on protected data routes (fail closed when roles are empty).
- Keep `GET /user/hasgroup` auth-only so the UI can probe membership during sign-in.
- Document the env var, OpenAPI for `/user/hasgroup`, and Cloud Run setup for dev/prod.

Closes #77

## Test plan
- [x] `npm test` passes (auth + user group tests included)
- [x] Confirm `ALLOWED_GROUP_EMAILS` is set on Cloud Run for the target env
- [x] Member of the full-access group can call data routes as before
- [x] Non-member gets `403` on data routes and `{ hasgroup: false }` from `/user/hasgroup`
- [x] Unset `ALLOWED_GROUP_EMAILS` locally still allows authenticated access (dev escape hatch)